### PR TITLE
Fix event loop blocking in setup and improve error handling

### DIFF
--- a/custom_components/sagecoffee/manifest.json
+++ b/custom_components/sagecoffee/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/simonjgreen/sageha",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/simonjgreen/sageha/issues",
-  "requirements": ["sagecoffee==0.1.1"],
-  "version": "1.0.1"
+  "requirements": ["sagecoffee==0.2.0rc1"],
+  "version": "1.1.0b1"
 }


### PR DESCRIPTION
## Summary
Refactored the setup entry flow to prevent blocking the Home Assistant event loop during SSL context initialization, and improved error handling to ensure proper client cleanup on setup failures.

## Key Changes
- **Moved SSL context creation to executor**: The `ssl_util.client_context()` call now runs in an executor via `hass.async_add_executor_job()` to avoid blocking the event loop, as certificate bundle loading performs blocking I/O operations
- **Restructured try-except block**: Moved client initialization outside the try block so that SSL context creation and client setup happen before attempting API operations
- **Added client cleanup on error**: Added `await client.__aexit__(None, None, None)` in the exception handler to properly clean up the client connection when setup fails
- **Updated dependencies**: Updated sagecoffee requirement from 0.1.1 to 0.2.0rc1 and bumped component version to 1.1.0b1

## Implementation Details
The SSL context creation was previously happening inside the try block without executor protection. By moving it to the executor, we ensure that blocking I/O operations don't freeze the event loop. The client is now initialized before the try block, allowing proper cleanup in the exception handler while keeping API operations (appliance discovery) within the try-except for appropriate error handling.

Hopefully fixes #6 