### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   validate:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - uses: "actions/checkout@v4"
       - uses: "home-assistant/actions/hassfest@master"


### PR DESCRIPTION
Potential fix for [https://github.com/simonjgreen/sageha/security/code-scanning/1](https://github.com/simonjgreen/sageha/security/code-scanning/1)

To fix the problem, explicitly declare least-privilege `GITHUB_TOKEN` permissions in the workflow. Since this workflow only checks out the repository and runs a validation action, it should only need read access to repository contents. The cleanest fix is to add a `permissions:` block at the job level under `validate:` with `contents: read`. This avoids changing behavior while ensuring the token cannot perform writes if repo defaults are permissive.

Concretely, in `.github/workflows/hassfest.yaml`, under `jobs: validate:` and at the same indentation level as `runs-on: "ubuntu-latest"`, insert:

```yaml
    permissions:
      contents: read
```

No imports or additional definitions are needed, as this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
