### PR TITLE
Add re-authentication flow

### DIFF
--- a/custom_components/sagecoffee/__init__.py
+++ b/custom_components/sagecoffee/__init__.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from typing import Any
 
+import httpx
+
 from sagecoffee import SageCoffeeClient
 from sagecoffee.auth import DEFAULT_CLIENT_ID
 
@@ -173,7 +175,13 @@ class SageCoffeeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("WebSocket listener cancelled")
             raise
         except Exception as err:
-            _LOGGER.exception("WebSocket error: %s", err)
+            if _is_auth_error(err):
+                _LOGGER.error(
+                    "Authentication failure detected, requesting re-auth: %s", err
+                )
+                self.config_entry.async_start_reauth(self.hass)
+            else:
+                _LOGGER.exception("WebSocket error: %s", err)
 
     async def async_stop_websocket(self) -> None:
         """Stop the WebSocket listener task."""
@@ -191,6 +199,19 @@ class SageCoffeeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def get_state(self, serial: str) -> dict[str, Any] | None:
         """Get the current state for an appliance."""
         return self._states.get(serial)
+
+
+def _is_auth_error(err: Exception) -> bool:
+    """Return True if the exception indicates an authentication failure."""
+    if isinstance(err, httpx.HTTPStatusError) and err.response.status_code in (
+        400,
+        401,
+        403,
+    ):
+        return True
+    if isinstance(err, ValueError) and "token" in str(err).lower():
+        return True
+    return False
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:

--- a/custom_components/sagecoffee/config_flow.py
+++ b/custom_components/sagecoffee/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -165,6 +166,127 @@ class SageCoffeeConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="token",
             data_schema=STEP_TOKEN_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "bootstrap_command": "sagectl bootstrap --username your.email@example.com"
+            },
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication."""
+        return self.async_show_menu(
+            step_id="reauth",
+            menu_options=["reauth_password", "reauth_token"],
+        )
+
+    async def async_step_reauth_password(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication via email and password."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                auth_client = AuthClient(client_id=DEFAULT_CLIENT_ID)
+                tokens = await auth_client.password_realm_login(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                )
+                entry = self.hass.config_entries.async_get_entry(
+                    self.context["entry_id"]
+                )
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={
+                        CONF_REFRESH_TOKEN: tokens.refresh_token,
+                        CONF_BRAND: user_input[CONF_BRAND],
+                    },
+                )
+            except AbortFlow:
+                raise
+            except Exception as err:
+                _LOGGER.exception("Re-authentication failed: %s", err)
+                errors["base"] = "invalid_auth"
+
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        existing_brand = (
+            entry.data.get(CONF_BRAND) if entry else None
+        ) or MACHINE_TYPE_SAGE
+
+        return self.async_show_form(
+            step_id="reauth_password",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.EMAIL)
+                    ),
+                    vol.Required(CONF_PASSWORD): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                    vol.Required(CONF_BRAND, default=existing_brand): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {"label": "Sage", "value": MACHINE_TYPE_SAGE},
+                                {"label": "Breville", "value": MACHINE_TYPE_BREVILLE},
+                            ]
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth_token(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication via refresh token."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            refresh_token = user_input[CONF_REFRESH_TOKEN]
+            try:
+                auth_client = AuthClient(client_id=DEFAULT_CLIENT_ID)
+                tokens = await auth_client.refresh(refresh_token)
+                entry = self.hass.config_entries.async_get_entry(
+                    self.context["entry_id"]
+                )
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={
+                        CONF_REFRESH_TOKEN: tokens.refresh_token or refresh_token,
+                        CONF_BRAND: user_input[CONF_BRAND],
+                    },
+                )
+            except AbortFlow:
+                raise
+            except Exception as err:
+                _LOGGER.exception("Re-authentication failed: %s", err)
+                errors["base"] = "invalid_auth"
+
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        existing_brand = (
+            entry.data.get(CONF_BRAND) if entry else None
+        ) or MACHINE_TYPE_SAGE
+
+        return self.async_show_form(
+            step_id="reauth_token",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_REFRESH_TOKEN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                    vol.Required(CONF_BRAND, default=existing_brand): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {"label": "Sage", "value": MACHINE_TYPE_SAGE},
+                                {"label": "Breville", "value": MACHINE_TYPE_BREVILLE},
+                            ]
+                        )
+                    ),
+                }
+            ),
             errors=errors,
             description_placeholders={
                 "bootstrap_command": "sagectl bootstrap --username your.email@example.com"

--- a/custom_components/sagecoffee/strings.json
+++ b/custom_components/sagecoffee/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     },
     "error": {
       "cannot_connect": "Unable to connect to Sage/Breville servers.",
@@ -42,6 +43,40 @@
           "token": "Use refresh token (advanced)"
         },
         "title": "Sage Coffee"
+      },
+      "reauth": {
+        "description": "Your Sage/Breville credentials need to be updated to restore the connection.",
+        "menu_options": {
+          "reauth_password": "Sign in with email and password",
+          "reauth_token": "Use refresh token (advanced)"
+        },
+        "title": "Re-authenticate Sage Coffee"
+      },
+      "reauth_password": {
+        "data": {
+          "brand": "Brand",
+          "password": "Password",
+          "username": "Email"
+        },
+        "data_description": {
+          "brand": "Select \"Sage\" if your machine was purchased in Europe, or \"Breville\" for the rest of the world.",
+          "username": "The email address associated with your Sage/Breville account.",
+          "password": "The password for your Sage/Breville account."
+        },
+        "description": "Enter your Sage/Breville account credentials.",
+        "title": "Re-authenticate Sage Coffee"
+      },
+      "reauth_token": {
+        "data": {
+          "brand": "Brand",
+          "refresh_token": "Refresh Token"
+        },
+        "data_description": {
+          "brand": "Select \"Sage\" if your machine was purchased in Europe, or \"Breville\" for the rest of the world.",
+          "refresh_token": "Paste the refresh token from your sagectl config file."
+        },
+        "description": "If you already have a refresh token from sagectl, paste it here.\n\nTo get a token, run:\n`{bootstrap_command}`",
+        "title": "Re-authenticate Sage Coffee"
       }
     }
   },

--- a/custom_components/sagecoffee/translations/en.json
+++ b/custom_components/sagecoffee/translations/en.json
@@ -9,6 +9,31 @@
           "token": "Use refresh token (advanced)"
         }
       },
+      "reauth": {
+        "title": "Re-authenticate Sage Coffee",
+        "description": "Your Sage/Breville credentials need to be updated to restore the connection.",
+        "menu_options": {
+          "reauth_password": "Sign in with email and password",
+          "reauth_token": "Use refresh token (advanced)"
+        }
+      },
+      "reauth_password": {
+        "title": "Re-authenticate Sage Coffee",
+        "description": "Enter your Sage/Breville account credentials.",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "brand": "Brand"
+        }
+      },
+      "reauth_token": {
+        "title": "Re-authenticate Sage Coffee",
+        "description": "If you already have a refresh token from sagectl, paste it here.\n\nTo get a token, run:\n`{bootstrap_command}`",
+        "data": {
+          "refresh_token": "Refresh Token",
+          "brand": "Brand"
+        }
+      },
       "password": {
         "title": "Sign in to Sage/Breville",
         "description": "Enter your Sage/Breville account credentials.",
@@ -33,7 +58,8 @@
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     }
   },
   "entity": {


### PR DESCRIPTION
Closes #28.

When credentials expire or become invalid, HA now shows a Repair issue with a Fix button rather than leaving the integration in a broken state. The fix triggers a reauth flow that mirrors initial setup (email/password or refresh token), then calls `async_update_reload_and_abort` to update credentials and reload — existing entities, automations, and history survive intact.

Auth failures detected at runtime via the WebSocket listener also trigger re-auth automatically instead of silently failing.