### PR TITLE
Remove duplicate read-only sensors and fix firmware version

### DIFF
--- a/custom_components/sagecoffee/light.py
+++ b/custom_components/sagecoffee/light.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN
+from .const import DOMAIN, STATE_ASLEEP
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +68,12 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
     @property
     def is_on(self) -> bool | None:
         """Return True if the work light is on."""
-        value = self._api_brightness()
+        state = self.coordinator.get_state(self._serial)
+        if state is None:
+            return None
+        if state.get("reported_state", "").lower() == STATE_ASLEEP:
+            return False
+        value = state.get("work_light_brightness")
         if value is None:
             return None
         return value > 0
@@ -79,7 +84,7 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
         value = self._api_brightness()
         if not value:
             return None
-        return value_to_brightness((0, 100), value)
+        return value_to_brightness((1, 100), value)
 
     @property
     def color_mode(self) -> ColorMode:
@@ -89,14 +94,13 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the work light."""
         ha_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-        # Convert HA scale (1–255) to API range (0–100), rounded to nearest 10
-        raw = brightness_to_value((0, 100), ha_brightness)
+        # Convert HA scale (1–255) to API range (1–100), rounded to nearest 10
+        raw = brightness_to_value((1, 100), ha_brightness)
         value = round(raw / 10) * 10
         # Ensure turning on always results in a visible brightness
         value = max(10, min(100, value))
-        await self.coordinator.client.set_coffee_params(
-            {"cfg": {"default": {"work_light_brightness": value}}},
-            serial=self._serial,
+        await self.coordinator.client.set_work_light_brightness(
+            value, serial=self._serial
         )
         state = self.coordinator.get_state(self._serial)
         if state is not None:
@@ -105,9 +109,8 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the work light."""
-        await self.coordinator.client.set_coffee_params(
-            {"cfg": {"default": {"work_light_brightness": 0}}},
-            serial=self._serial,
+        await self.coordinator.client.set_work_light_brightness(
+            0, serial=self._serial
         )
         state = self.coordinator.get_state(self._serial)
         if state is not None:

--- a/custom_components/sagecoffee/number.py
+++ b/custom_components/sagecoffee/number.py
@@ -38,8 +38,8 @@ NUMBER_DESCRIPTIONS: tuple[SageCoffeeNumberEntityDescription, ...] = (
         native_max_value=100,
         native_step=10,
         value_fn=lambda state: state.get("brightness"),
-        set_fn=lambda coordinator, serial, value: coordinator.client.set_coffee_params(
-            {"cfg": {"default": {"brightness": int(value)}}}, serial=serial
+        set_fn=lambda coordinator, serial, value: coordinator.client.set_brightness(
+            int(value), serial
         ),
     ),
     SageCoffeeNumberEntityDescription(
@@ -49,8 +49,8 @@ NUMBER_DESCRIPTIONS: tuple[SageCoffeeNumberEntityDescription, ...] = (
         native_max_value=100,
         native_step=10,
         value_fn=lambda state: state.get("volume"),
-        set_fn=lambda coordinator, serial, value: coordinator.client.set_coffee_params(
-            {"cfg": {"default": {"vol": int(value)}}}, serial=serial
+        set_fn=lambda coordinator, serial, value: coordinator.client.set_volume(
+            int(value), serial
         ),
     ),
 )

--- a/custom_components/sagecoffee/number.py
+++ b/custom_components/sagecoffee/number.py
@@ -34,6 +34,7 @@ NUMBER_DESCRIPTIONS: tuple[SageCoffeeNumberEntityDescription, ...] = (
     SageCoffeeNumberEntityDescription(
         key="brightness",
         translation_key="display_brightness",
+        icon="mdi:brightness-6",
         native_min_value=0,
         native_max_value=100,
         native_step=10,
@@ -45,6 +46,7 @@ NUMBER_DESCRIPTIONS: tuple[SageCoffeeNumberEntityDescription, ...] = (
     SageCoffeeNumberEntityDescription(
         key="volume",
         translation_key="volume_level",
+        icon="mdi:volume-high",
         native_min_value=0,
         native_max_value=100,
         native_step=10,

--- a/custom_components/sagecoffee/select.py
+++ b/custom_components/sagecoffee/select.py
@@ -41,6 +41,7 @@ class SageCoffeeThemeSelect(CoordinatorEntity[SageCoffeeCoordinator], SelectEnti
 
     _attr_has_entity_name = True
     _attr_translation_key = "color_theme"
+    _attr_icon = "mdi:palette"
     _attr_options = AVAILABLE_THEMES
 
     def __init__(

--- a/custom_components/sagecoffee/sensor.py
+++ b/custom_components/sagecoffee/sensor.py
@@ -166,34 +166,11 @@ SENSOR_DESCRIPTIONS: tuple[SageCoffeeSensorEntityDescription, ...] = (
         value_fn=lambda state: _get_boiler_target(state, BOILER_STEAM),
     ),
     SageCoffeeSensorEntityDescription(
-        key="theme",
-        translation_key="theme",
-        name="Theme",
-        icon="mdi:palette",
-        value_fn=lambda state: state.get("theme"),
-    ),
-    SageCoffeeSensorEntityDescription(
-        key="brightness",
-        translation_key="brightness",
-        name="Display Brightness",
-        icon="mdi:brightness-6",
-        native_unit_of_measurement="%",
-        value_fn=lambda state: state.get("brightness"),
-    ),
-    SageCoffeeSensorEntityDescription(
         key="grind_size",
         translation_key="grind_size",
         name="Grind Size",
         icon="mdi:grain",
         value_fn=lambda state: state.get("grind_size"),
-    ),
-    SageCoffeeSensorEntityDescription(
-        key="volume",
-        translation_key="volume",
-        name="Volume",
-        icon="mdi:volume-high",
-        native_unit_of_measurement="%",
-        value_fn=lambda state: state.get("volume"),
     ),
     SageCoffeeSensorEntityDescription(
         key="auto_off",
@@ -210,7 +187,7 @@ SENSOR_DESCRIPTIONS: tuple[SageCoffeeSensorEntityDescription, ...] = (
         name="Firmware Version",
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda state: (state.get("firmware") or {}).get("version"),
+        value_fn=lambda state: (state.get("firmware") or {}).get("appVersion"),
     ),
     SageCoffeeSensorEntityDescription(
         key="wake_schedule_next",

--- a/custom_components/sagecoffee/strings.json
+++ b/custom_components/sagecoffee/strings.json
@@ -109,9 +109,6 @@
       "brew_temperature": {
         "name": "Brew Temperature"
       },
-      "brightness": {
-        "name": "Display Brightness"
-      },
       "grind_size": {
         "name": "Grind Size"
       },
@@ -123,12 +120,6 @@
       },
       "steam_temperature": {
         "name": "Steam Temperature"
-      },
-      "theme": {
-        "name": "Theme"
-      },
-      "volume": {
-        "name": "Volume"
       },
       "firmware_version": {
         "name": "Firmware Version"

--- a/custom_components/sagecoffee/translations/en.json
+++ b/custom_components/sagecoffee/translations/en.json
@@ -79,17 +79,8 @@
       "steam_target": {
         "name": "Steam Target Temperature"
       },
-      "theme": {
-        "name": "Theme"
-      },
-      "brightness": {
-        "name": "Display Brightness"
-      },
       "grind_size": {
         "name": "Grind Size"
-      },
-      "volume": {
-        "name": "Volume"
       },
       "auto_off": {
         "name": "Auto-off Time"


### PR DESCRIPTION
## Summary

- Removes `sensor.brightness`, `sensor.volume`, and `sensor.theme` — these were redundant read-only duplicates of `number.display_brightness`, `number.volume_level`, and `select.color_theme` respectively. Each writable entity already shows its current value; having a separate sensor alongside it just clutters the device page.
- Transfers the icons from the removed sensors to their controllable counterparts (`mdi:brightness-6`, `mdi:volume-high`, `mdi:palette`) so nothing is lost visually.
- Fixes `sensor.firmware_version` which has always shown "unknown". The device firmware dict uses `appVersion` as the key, not `version` as the code expected.
- `sensor.grind_size` is kept — there is no writable counterpart for it.

## Test plan
- [ ] Device page shows one entity per property — no duplicate brightness/volume/theme entities
- [ ] `number.display_brightness` shows `mdi:brightness-6` icon
- [ ] `number.volume_level` shows `mdi:volume-high` icon
- [ ] `select.color_theme` shows `mdi:palette` icon
- [ ] `sensor.firmware_version` shows the actual firmware version (e.g. `1.1.30`) instead of "unknown"