### PR TITLE
Extract shared SageCoffeeEntity base class

### DIFF
--- a/custom_components/sagecoffee/entity.py
+++ b/custom_components/sagecoffee/entity.py
@@ -1,0 +1,40 @@
+"""Base entity class for Sage Coffee integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import SageCoffeeCoordinator
+from .const import DOMAIN
+
+
+class SageCoffeeEntity(CoordinatorEntity[SageCoffeeCoordinator]):
+    """Base entity class for Sage Coffee devices."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SageCoffeeCoordinator,
+        appliance: Any,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._appliance = appliance
+        self._serial = appliance.serial_number
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial)},
+            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
+            manufacturer="Sage/Breville",
+            model=appliance.model or "Unknown",
+            serial_number=self._serial,
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/sagecoffee/light.py
+++ b/custom_components/sagecoffee/light.py
@@ -6,14 +6,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN, STATE_ASLEEP
+from .const import STATE_ASLEEP
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,10 +31,9 @@ async def async_setup_entry(
     )
 
 
-class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity):
+class SageCoffeeWorkLight(SageCoffeeEntity, LightEntity):
     """Represents the work light (cup warmer illumination) on a Sage Coffee machine."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "work_light"
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
@@ -46,17 +44,8 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
         appliance: Any,
     ) -> None:
         """Initialize the work light."""
-        super().__init__(coordinator)
-        self._appliance = appliance
-        self._serial = appliance.serial_number
+        super().__init__(coordinator, appliance)
         self._attr_unique_id = f"{self._serial}_work_light"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     def _api_brightness(self) -> int | None:
         """Return the current work light brightness from the API (0–100), or None."""
@@ -117,7 +106,3 @@ class SageCoffeeWorkLight(CoordinatorEntity[SageCoffeeCoordinator], LightEntity)
             state["work_light_brightness"] = 0
             self.coordinator.async_set_updated_data(self.coordinator.data)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()

--- a/custom_components/sagecoffee/number.py
+++ b/custom_components/sagecoffee/number.py
@@ -11,13 +11,12 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN, STATE_ASLEEP
+from .const import STATE_ASLEEP
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,11 +74,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SageCoffeeNumber(CoordinatorEntity[SageCoffeeCoordinator], NumberEntity):
+class SageCoffeeNumber(SageCoffeeEntity, NumberEntity):
     """Represents a Sage Coffee number entity."""
 
     entity_description: SageCoffeeNumberEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -88,20 +86,9 @@ class SageCoffeeNumber(CoordinatorEntity[SageCoffeeCoordinator], NumberEntity):
         description: SageCoffeeNumberEntityDescription,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, appliance)
         self.entity_description = description
-        self._appliance = appliance
-        self._serial = appliance.serial_number
         self._attr_unique_id = f"{self._serial}_{description.key}"
-
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/sagecoffee/select.py
+++ b/custom_components/sagecoffee/select.py
@@ -6,13 +6,12 @@ import logging
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN, STATE_ASLEEP
+from .const import STATE_ASLEEP
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,10 +35,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SageCoffeeThemeSelect(CoordinatorEntity[SageCoffeeCoordinator], SelectEntity):
+class SageCoffeeThemeSelect(SageCoffeeEntity, SelectEntity):
     """Represents the color theme select."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "color_theme"
     _attr_icon = "mdi:palette"
     _attr_options = AVAILABLE_THEMES
@@ -50,19 +48,8 @@ class SageCoffeeThemeSelect(CoordinatorEntity[SageCoffeeCoordinator], SelectEnti
         appliance: Any,
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(coordinator)
-        self._appliance = appliance
-        self._serial = appliance.serial_number
+        super().__init__(coordinator, appliance)
         self._attr_unique_id = f"{self._serial}_color_theme"
-
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/sagecoffee/sensor.py
+++ b/custom_components/sagecoffee/sensor.py
@@ -16,13 +16,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import BOILER_BREW, BOILER_STEAM, DOMAIN
+from .const import BOILER_BREW, BOILER_STEAM
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -217,11 +216,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SageCoffeeSensor(CoordinatorEntity[SageCoffeeCoordinator], SensorEntity):
+class SageCoffeeSensor(SageCoffeeEntity, SensorEntity):
     """Represents a sensor for a Sage Coffee machine."""
 
     entity_description: SageCoffeeSensorEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -230,20 +228,9 @@ class SageCoffeeSensor(CoordinatorEntity[SageCoffeeCoordinator], SensorEntity):
         description: SageCoffeeSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, appliance)
         self.entity_description = description
-        self._appliance = appliance
-        self._serial = appliance.serial_number
         self._attr_unique_id = f"{self._serial}_{description.key}"
-
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     @property
     def native_value(self) -> Any:
@@ -253,7 +240,3 @@ class SageCoffeeSensor(CoordinatorEntity[SageCoffeeCoordinator], SensorEntity):
             return None
         return self.entity_description.value_fn(state)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()

--- a/custom_components/sagecoffee/switch.py
+++ b/custom_components/sagecoffee/switch.py
@@ -6,13 +6,12 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN, STATE_READY, STATE_WARMING
+from .const import STATE_READY, STATE_WARMING
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,11 +32,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SageCoffeePowerSwitch(CoordinatorEntity[SageCoffeeCoordinator], SwitchEntity):
+class SageCoffeePowerSwitch(SageCoffeeEntity, SwitchEntity):
     """Represents the power state of a Sage Coffee machine."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
-    _attr_has_entity_name = True
     _attr_translation_key = "power"
 
     def __init__(
@@ -46,19 +44,8 @@ class SageCoffeePowerSwitch(CoordinatorEntity[SageCoffeeCoordinator], SwitchEnti
         appliance: Any,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator)
-        self._appliance = appliance
-        self._serial = appliance.serial_number
+        super().__init__(coordinator, appliance)
         self._attr_unique_id = f"{self._serial}_power"
-
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     @property
     def is_on(self) -> bool | None:
@@ -98,7 +85,3 @@ class SageCoffeePowerSwitch(CoordinatorEntity[SageCoffeeCoordinator], SwitchEnti
             _LOGGER.error("Failed to put coffee machine to sleep: %s", err)
             raise
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()

--- a/custom_components/sagecoffee/text.py
+++ b/custom_components/sagecoffee/text.py
@@ -6,13 +6,11 @@ import logging
 from typing import Any
 
 from homeassistant.components.text import TextEntity
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
-from .const import DOMAIN, STATE_ASLEEP
+from .entity import SageCoffeeEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,10 +31,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SageCoffeeApplianceNameText(CoordinatorEntity[SageCoffeeCoordinator], TextEntity):
+class SageCoffeeApplianceNameText(SageCoffeeEntity, TextEntity):
     """Represents the appliance name text input."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "appliance_name"
     _attr_native_max = 20
 
@@ -46,19 +43,8 @@ class SageCoffeeApplianceNameText(CoordinatorEntity[SageCoffeeCoordinator], Text
         appliance: Any,
     ) -> None:
         """Initialize the text entity."""
-        super().__init__(coordinator)
-        self._appliance = appliance
-        self._serial = appliance.serial_number
+        super().__init__(coordinator, appliance)
         self._attr_unique_id = f"{self._serial}_appliance_name"
-
-        # Device info
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial)},
-            name=appliance.name or f"Sage Coffee {self._serial[-4:]}",
-            manufacturer="Sage/Breville",
-            model=appliance.model or "Unknown",
-            serial_number=self._serial,
-        )
 
     @property
     def native_value(self) -> str | None:


### PR DESCRIPTION
## Summary

- Adds `entity.py` with a `SageCoffeeEntity(CoordinatorEntity)` base class
- Moves the `DeviceInfo` block, `_attr_has_entity_name`, and `_handle_coordinator_update` out of all six platform files and into the base class
- All entity classes now inherit from `SageCoffeeEntity` + their HA platform type

Net result: 69 lines added, 118 removed. Device metadata is now defined once.

Closes #14

## Test plan

- [x] Integration loads without errors
- [x] All entities appear under the correct device in HA
- [x] State updates from WebSocket reflected correctly across all platforms
- [x] Work light on/off and brightness control works
- [x] Switch, sensors, number, select, and text entities behave as before