### PR TITLE
Fix wake_schedule type mismatch crashing WebSocket listener (#36)

### DIFF
--- a/custom_components/sagecoffee/__init__.py
+++ b/custom_components/sagecoffee/__init__.py
@@ -92,6 +92,12 @@ class SageCoffeeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _update_state_from_device(self, state: Any) -> None:
         """Update internal state from a DeviceState object."""
         serial = state.serial_number
+        raw_schedule = (
+            state.raw_data.get("reported", {})
+            .get("cfg", {})
+            .get("default", {})
+            .get("wake_schedule")
+        )
         self._states[serial] = {
             "reported_state": state.reported_state,
             "desired_state": state.desired_state,
@@ -124,11 +130,9 @@ class SageCoffeeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             .get("cfg", {})
             .get("default", {})
             .get("timezone"),
-            "wake_schedule": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("wake_schedule")
-            or [],
+            "wake_schedule": [
+                s for s in raw_schedule if isinstance(s, dict)
+            ] if isinstance(raw_schedule, list) else [],
             "firmware": state.raw_data.get("reported", {}).get("firmware", {}),
         }
 

--- a/custom_components/sagecoffee/sensor.py
+++ b/custom_components/sagecoffee/sensor.py
@@ -57,13 +57,16 @@ def _parse_cron_next(
     if days_str == "*":
         allowed = set(range(7))
     else:
-        for part in days_str.split(","):
-            if "-" in part:
-                start, end = part.split("-", 1)
-                for d in range(int(start), int(end) + 1):
-                    allowed.add((d - 1) % 7)
-            else:
-                allowed.add((int(part) - 1) % 7)
+        try:
+            for part in days_str.split(","):
+                if "-" in part:
+                    start, end = part.split("-", 1)
+                    for d in range(int(start), int(end) + 1):
+                        allowed.add((d - 1) % 7)
+                else:
+                    allowed.add((int(part) - 1) % 7)
+        except ValueError:
+            return None
 
     # Walk forward up to 8 days to find the next matching slot
     candidate = after.replace(second=0, microsecond=0)
@@ -90,9 +93,12 @@ def _get_next_wake_time(state: dict[str, Any]) -> datetime | None:
     now = datetime.now(tz)
     next_wake: datetime | None = None
     for entry in schedules:
-        if not entry.get("on"):
+        if not isinstance(entry, dict) or not entry.get("on"):
             continue
-        dt = _parse_cron_next(entry.get("cron", ""), now, tz)
+        cron = entry.get("cron", "")
+        if not isinstance(cron, str):
+            continue
+        dt = _parse_cron_next(cron, now, tz)
         if dt is not None and (next_wake is None or dt < next_wake):
             next_wake = dt
 


### PR DESCRIPTION
Device returns wake_schedule as the string "none" instead of the expected empty array, causing AttributeError in _get_next_wake_time and crashing the WebSocket listener for the rest of the session.

- Normalise wake_schedule at coordinator level: only accept list of dicts
- Add isinstance guards in _get_next_wake_time for entries and cron values
- Wrap cron day-of-week parsing in try/except for malformed strings