### PR TITLE
Add Sage Coffee diagnostic sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,17 @@ For each coffee machine, the integration creates:
 | Volume                   | Volume level percentage                        |
 | Auto-off Time            | Idle time before auto-sleep (minutes)          |
 | Next Wake Time           | Next scheduled automatic wake time             |
+| Wake Schedule            | Raw wake schedule summary                      |
+| Temperature Unit         | Configured temperature unit                    |
+| Timezone                 | Configured machine timezone                    |
+| Remote Wake              | Whether remote wake is enabled                 |
+| Last Paired              | Last cloud pairing timestamp                   |
+| State Report Version     | Latest WebSocket state report version          |
 | Firmware Version         | Installed firmware version (diagnostic)        |
+| MCU Firmware Version     | Installed MCU firmware version (diagnostic)    |
+| OTA Service Version      | Installed OTA service version (diagnostic)     |
+| SOM Image Version        | Installed SOM image version (diagnostic)       |
+| Errors Count             | Number of appliance errors reported            |
 
 ## Actions
 

--- a/custom_components/sagecoffee/__init__.py
+++ b/custom_components/sagecoffee/__init__.py
@@ -92,48 +92,46 @@ class SageCoffeeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _update_state_from_device(self, state: Any) -> None:
         """Update internal state from a DeviceState object."""
         serial = state.serial_number
-        raw_schedule = (
-            state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("wake_schedule")
-        )
+        reported = state.raw_data.get("reported", {})
+        cfg_default = reported.get("cfg", {}).get("default", {})
+        if not isinstance(cfg_default, dict):
+            cfg_default = {}
+        if not cfg_default:
+            cfg_default = reported.get("cfg.default", {})
+            if not isinstance(cfg_default, dict):
+                cfg_default = {}
+        pairing = reported.get("pairing", {})
+        if not isinstance(pairing, dict):
+            pairing = {}
+        raw_schedule = cfg_default.get("wake_schedule")
         self._states[serial] = {
             "reported_state": state.reported_state,
             "desired_state": state.desired_state,
+            "state_report_version": state.version,
+            "reported_version": reported.get("version"),
+            "model": reported.get("model"),
             "boiler_temps": [
                 {"id": b.id, "cur_temp": b.current_temp, "temp_sp": b.target_temp}
                 for b in (state.boiler_temps or [])
             ],
             "grind_size": state.grind_size,
-            "theme": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("theme"),
-            "brightness": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("brightness"),
-            "work_light_brightness": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("work_light_brightness"),
-            "volume": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("vol"),
-            "idle_time": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("idle_time"),
-            "timezone": state.raw_data.get("reported", {})
-            .get("cfg", {})
-            .get("default", {})
-            .get("timezone"),
+            "theme": cfg_default.get("theme"),
+            "brightness": cfg_default.get("brightness"),
+            "work_light_brightness": cfg_default.get("work_light_brightness"),
+            "volume": cfg_default.get("vol"),
+            "idle_time": cfg_default.get("idle_time"),
+            "temperature_unit": cfg_default.get("temp_unit"),
+            "timezone": cfg_default.get("timezone"),
+            "remote_wake": pairing.get(
+                "remote_wake", cfg_default.get("remote_wake_enable")
+            ),
+            "last_paired": pairing.get("last_paired"),
+            "wake_schedule_raw": raw_schedule,
             "wake_schedule": [
                 s for s in raw_schedule if isinstance(s, dict)
             ] if isinstance(raw_schedule, list) else [],
-            "firmware": state.raw_data.get("reported", {}).get("firmware", {}),
+            "firmware": reported.get("firmware", {}),
+            "errors": reported.get("errors"),
         }
 
     async def async_start_websocket(self) -> None:

--- a/custom_components/sagecoffee/sensor.py
+++ b/custom_components/sagecoffee/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any
 import zoneinfo
@@ -124,6 +124,70 @@ def _get_boiler_target(state: dict[str, Any], boiler_id: int | str) -> float | N
     return None
 
 
+def _format_temperature_unit(state: dict[str, Any]) -> str | None:
+    """Return the configured temperature unit."""
+    unit = state.get("temperature_unit")
+    if unit == 0:
+        return "Celsius"
+    if unit == 1:
+        return "Fahrenheit"
+    if unit is None:
+        return None
+    return str(unit)
+
+
+def _format_remote_wake(state: dict[str, Any]) -> str | None:
+    """Return whether remote wake is enabled."""
+    remote_wake = state.get("remote_wake")
+    if remote_wake is True:
+        return "enabled"
+    if remote_wake is False:
+        return "disabled"
+    return None
+
+
+def _get_last_paired(state: dict[str, Any]) -> datetime | None:
+    """Return the last paired timestamp from an epoch value."""
+    last_paired = state.get("last_paired")
+    if last_paired in (None, "", "none"):
+        return None
+    try:
+        timestamp = float(last_paired)
+    except (TypeError, ValueError):
+        return None
+    if timestamp > 10_000_000_000:
+        timestamp /= 1000
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+def _get_errors_count(state: dict[str, Any]) -> int | None:
+    """Return the number of reported appliance errors."""
+    errors = state.get("errors")
+    if isinstance(errors, list):
+        return len(errors)
+    return None
+
+
+def _format_wake_schedule(state: dict[str, Any]) -> str | None:
+    """Return a compact wake schedule summary."""
+    schedule = state.get("wake_schedule_raw")
+    if schedule in (None, "", "none"):
+        return "none"
+    if isinstance(schedule, list):
+        if not schedule:
+            return "none"
+        entries: list[str] = []
+        for entry in schedule:
+            if not isinstance(entry, dict):
+                continue
+            cron = entry.get("cron")
+            if not cron:
+                continue
+            entries.append(f"{cron} ({'on' if entry.get('on') else 'off'})")
+        return ", ".join(entries) if entries else None
+    return str(schedule)
+
+
 SENSOR_DESCRIPTIONS: tuple[SageCoffeeSensorEntityDescription, ...] = (
     SageCoffeeSensorEntityDescription(
         key="state",
@@ -195,12 +259,93 @@ SENSOR_DESCRIPTIONS: tuple[SageCoffeeSensorEntityDescription, ...] = (
         value_fn=lambda state: (state.get("firmware") or {}).get("appVersion"),
     ),
     SageCoffeeSensorEntityDescription(
+        key="firmware_mcu0",
+        translation_key="firmware_mcu0",
+        name="MCU Firmware Version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: (state.get("firmware") or {}).get("mcu0"),
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="firmware_ota_service",
+        translation_key="firmware_ota_service",
+        name="OTA Service Version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: (state.get("firmware") or {}).get("otaServiceVersion"),
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="firmware_sompro_image",
+        translation_key="firmware_sompro_image",
+        name="SOM Image Version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: (state.get("firmware") or {}).get("sompro_image"),
+    ),
+    SageCoffeeSensorEntityDescription(
         key="wake_schedule_next",
         translation_key="wake_schedule_next",
         name="Next Wake Time",
         icon="mdi:alarm",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=_get_next_wake_time,
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="wake_schedule",
+        translation_key="wake_schedule",
+        name="Wake Schedule",
+        icon="mdi:alarm",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_format_wake_schedule,
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="temperature_unit",
+        translation_key="temperature_unit",
+        name="Temperature Unit",
+        icon="mdi:thermometer",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_format_temperature_unit,
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="timezone",
+        translation_key="timezone",
+        name="Timezone",
+        icon="mdi:map-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: state.get("timezone"),
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="remote_wake",
+        translation_key="remote_wake",
+        name="Remote Wake",
+        icon="mdi:power-settings",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_format_remote_wake,
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="last_paired",
+        translation_key="last_paired",
+        name="Last Paired",
+        icon="mdi:link-variant",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_get_last_paired,
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="state_report_version",
+        translation_key="state_report_version",
+        name="State Report Version",
+        icon="mdi:counter",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: state.get("state_report_version"),
+    ),
+    SageCoffeeSensorEntityDescription(
+        key="errors_count",
+        translation_key="errors_count",
+        name="Errors Count",
+        icon="mdi:alert-circle-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_get_errors_count,
     ),
 )
 

--- a/custom_components/sagecoffee/strings.json
+++ b/custom_components/sagecoffee/strings.json
@@ -124,8 +124,38 @@
       "firmware_version": {
         "name": "Firmware Version"
       },
+      "firmware_mcu0": {
+        "name": "MCU Firmware Version"
+      },
+      "firmware_ota_service": {
+        "name": "OTA Service Version"
+      },
+      "firmware_sompro_image": {
+        "name": "SOM Image Version"
+      },
       "wake_schedule_next": {
         "name": "Next Wake Time"
+      },
+      "wake_schedule": {
+        "name": "Wake Schedule"
+      },
+      "temperature_unit": {
+        "name": "Temperature Unit"
+      },
+      "timezone": {
+        "name": "Timezone"
+      },
+      "remote_wake": {
+        "name": "Remote Wake"
+      },
+      "last_paired": {
+        "name": "Last Paired"
+      },
+      "state_report_version": {
+        "name": "State Report Version"
+      },
+      "errors_count": {
+        "name": "Errors Count"
       }
     },
     "switch": {

--- a/custom_components/sagecoffee/translations/en.json
+++ b/custom_components/sagecoffee/translations/en.json
@@ -88,8 +88,38 @@
       "firmware_version": {
         "name": "Firmware Version"
       },
+      "firmware_mcu0": {
+        "name": "MCU Firmware Version"
+      },
+      "firmware_ota_service": {
+        "name": "OTA Service Version"
+      },
+      "firmware_sompro_image": {
+        "name": "SOM Image Version"
+      },
       "wake_schedule_next": {
         "name": "Next Wake Time"
+      },
+      "wake_schedule": {
+        "name": "Wake Schedule"
+      },
+      "temperature_unit": {
+        "name": "Temperature Unit"
+      },
+      "timezone": {
+        "name": "Timezone"
+      },
+      "remote_wake": {
+        "name": "Remote Wake"
+      },
+      "last_paired": {
+        "name": "Last Paired"
+      },
+      "state_report_version": {
+        "name": "State Report Version"
+      },
+      "errors_count": {
+        "name": "Errors Count"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary
- add diagnostic/config sensors for Sage/Breville raw telemetry already present in state reports
- surface MCU, OTA service, and SOM image firmware versions
- surface wake schedule, temperature unit, timezone, remote wake, last paired, state report version, and errors count
- document the new entities in the README

## Validation
- `python -m compileall -q custom_components/sagecoffee`
- parsed `custom_components/sagecoffee/strings.json` and `custom_components/sagecoffee/translations/en.json`
- `git diff --check`

## Notes
The added fields were observed in live WebSocket state reports from a BES995 Oracle Dual Boiler. This keeps the PR scoped to proven telemetry and avoids speculative usage, recipe, water, service, or power sensors that were not present in the observed payloads.