### PR TITLE
Auto-create git tag when manifest version bumps

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,36 @@
+name: Tag release from manifest version
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - custom_components/sagecoffee/manifest.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r .version custom_components/sagecoffee/manifest.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if missing
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- Add a workflow that watches `custom_components/sagecoffee/manifest.json` on pushes to `main`
- When the `version` field changes, CI creates and pushes a matching `vX.Y.Z` tag (no-op if the tag already exists)
- GitHub Releases are still drafted manually from the resulting tag, so the manifest version and release tag can't drift apart

## Test plan
- [ ] Merge to main, bump `version` in manifest.json in a follow-up commit, confirm the workflow creates the matching tag
- [ ] Confirm no tag/PR is created for manifest edits that don't touch `version` (path filter still triggers, but tag creation is a no-op if unchanged... verify version diff isn't silently skipped when unchanged)