### PR TITLE
Fix disable_wake_schedule not taking effect

### DIFF
--- a/custom_components/sagecoffee/__init__.py
+++ b/custom_components/sagecoffee/__init__.py
@@ -284,8 +284,19 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
         coordinator = entry.runtime_data
 
         try:
-            # Call the API to disable wake schedule
-            await coordinator.client.disable_wake_schedule(serial=serial)
+            # The device silently ignores an empty wake_schedule list, so the
+            # schedule can't be cleared outright. Instead, preserve the known
+            # entries and flip each one's "on" flag to False.
+            state = coordinator.get_state(serial) or {}
+            current_schedule = state.get("wake_schedule") or []
+            if current_schedule:
+                disabled_schedule = [
+                    {**s, "on": False} for s in current_schedule
+                ]
+                await coordinator.client.set_coffee_params(
+                    {"cfg": {"wake_schedule": disabled_schedule}},
+                    serial=serial,
+                )
         except Exception as err:
             raise HomeAssistantError(f"Failed to disable wake schedule: {err}") from err
 


### PR DESCRIPTION
## Summary
- Fixes #41: calling the `disable_wake_schedule` action didn't actually disable the wake schedule
- Root cause, confirmed against a real Oracle Dual Boiler (BES995): the device silently ignores `set-coffeeParams` calls with an empty `wake_schedule` array. The HTTP API returns `"successful update"`, but the change is dropped — the device's `reported` state (and in one test, the AWS IoT shadow `desired`/`delta`) never reflects it, so the schedule stays active
- Fix: `disable_wake_schedule` now reuses the coordinator's cached schedule (already tracked from the WebSocket state stream) and resends it with each entry's `"on"` flag set to `false`, instead of sending an empty list. This was also verified to correctly preserve multiple schedule entries — the device supports more than one `wake_schedule` entry, and a naive single-entry replacement would silently discard any others

## Test plan
- [x] Reproduced the bug live: confirmed `wake_schedule: []` is silently dropped by the API (reported state / shadow delta never changes)
- [x] Confirmed `on: false` with the schedule's cron preserved is accepted and resolves correctly once the appliance is awake
- [x] Confirmed the device supports and preserves multiple `wake_schedule` entries (sent 2, both persisted in `reported`)
- [x] Exercised the exact `set_coffee_params` call this fix uses against the real appliance and confirmed the schedule was disabled with the cron preserved
- [x] Restored the appliance's original wake schedule afterward
- [x] `python3 -m py_compile` on the changed file