### PR TITLE
Bump version to 1.4.0-beta

### DIFF
--- a/custom_components/sagecoffee/manifest.json
+++ b/custom_components/sagecoffee/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/simonjgreen/sageha/issues",
   "requirements": ["sagecoffee==0.2.0"],
-  "version": "1.3.2"
+  "version": "1.4.0-beta"
 }


### PR DESCRIPTION
## Summary
- Bump `manifest.json` version to `1.4.0-beta` ahead of the 1.4.0 release
- Merging this to `main` will trigger the auto-tag workflow (#46) to push `v1.4.0-beta`, ready for a GitHub Release to be drafted from it

## Test plan
- [x] Validated `1.4.0-beta` parses correctly as a beta pre-release via `awesomeversion` (the library HA/HACS use for manifest version parsing)