### PR TITLE
Promote 1.4.0-beta to stable release

### DIFF
--- a/custom_components/sagecoffee/manifest.json
+++ b/custom_components/sagecoffee/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/simonjgreen/sageha/issues",
   "requirements": ["sagecoffee==0.2.0"],
-  "version": "1.4.0-beta"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
## Summary
- Bump `manifest.json` version from `1.4.0-beta` to `1.4.0` to promote the beta to a stable release
- Merging this to `main` will trigger the auto-tag workflow to push `v1.4.0`, ready for a GitHub Release to be drafted from it

## Test plan
- [x] Confirmed `manifest.json` is valid JSON after the edit