### PR TITLE
Migrate legacy machine_type config entries to brand (1.4.1)

### DIFF
--- a/custom_components/sagecoffee/__init__.py
+++ b/custom_components/sagecoffee/__init__.py
@@ -25,7 +25,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import ssl as ssl_util
 import voluptuous as vol
 
-from .const import CONF_BRAND, CONF_REFRESH_TOKEN, DOMAIN, PLATFORMS
+from .const import (
+    CONF_BRAND,
+    CONF_MACHINE_TYPE_LEGACY,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    MACHINE_TYPE_SAGE,
+    PLATFORMS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -320,6 +327,32 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     return True
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate an old config entry to the current schema."""
+    _LOGGER.debug("Migrating configuration from version %s", entry.version)
+
+    if entry.version > 2:
+        # Downgraded from a newer version of the integration, nothing we can do
+        return False
+
+    if entry.version == 1:
+        # Version 1 stored the brand under "machine_type" (renamed in 1.3.0).
+        # Entries created before the rename leave "brand" unset, which used to
+        # send a None app identifier to the API and fail with an opaque error.
+        data = {**entry.data}
+        brand = (
+            data.pop(CONF_MACHINE_TYPE_LEGACY, None)
+            or data.get(CONF_BRAND)
+            or MACHINE_TYPE_SAGE
+        )
+        data[CONF_BRAND] = brand
+
+        hass.config_entries.async_update_entry(entry, data=data, version=2)
+        _LOGGER.debug("Migrated config entry to version 2 with brand %s", brand)
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: SageCoffeeConfigEntry) -> bool:
     """Set up Sage Coffee from a config entry."""
     refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
@@ -336,7 +369,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SageCoffeeConfigEntry) -
     client = SageCoffeeClient(
         client_id=DEFAULT_CLIENT_ID,
         refresh_token=refresh_token,
-        app=entry.data.get(CONF_BRAND),
+        app=entry.data.get(CONF_BRAND) or MACHINE_TYPE_SAGE,
         httpx_client=http_client,
         ssl_context=ssl_context,
     )
@@ -351,7 +384,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SageCoffeeConfigEntry) -
         _LOGGER.debug("Found %d appliances", len(appliances))
 
     except Exception as err:
-        _LOGGER.error("Failed to connect to Sage Coffee API: %s", err)
+        _LOGGER.error(
+            "Failed to connect to Sage Coffee API: %s: %s", type(err).__name__, err
+        )
         await client.__aexit__(None, None, None)
         raise ConfigEntryNotReady from err
 

--- a/custom_components/sagecoffee/config_flow.py
+++ b/custom_components/sagecoffee/config_flow.py
@@ -69,7 +69,7 @@ STEP_TOKEN_DATA_SCHEMA = vol.Schema(
 class SageCoffeeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sage Coffee."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/sagecoffee/const.py
+++ b/custom_components/sagecoffee/const.py
@@ -6,6 +6,9 @@ DOMAIN = "sagecoffee"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_BRAND = "brand"
 
+# Legacy configuration keys (migrated on setup)
+CONF_MACHINE_TYPE_LEGACY = "machine_type"
+
 # Machine type values
 MACHINE_TYPE_SAGE = "sageCoffee"
 MACHINE_TYPE_BREVILLE = "brevilleCoffee"

--- a/custom_components/sagecoffee/manifest.json
+++ b/custom_components/sagecoffee/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/simonjgreen/sageha",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/simonjgreen/sageha/issues",
-  "requirements": ["sagecoffee==0.2.0"],
-  "version": "1.4.0"
+  "requirements": ["sagecoffee==0.2.1"],
+  "version": "1.4.1"
 }


### PR DESCRIPTION
## Summary

Fixes #54. Config entries created before the `machine_type` -> `brand` rename (fdb1ac9, shipped in v1.3.x/v1.4.0) left `CONF_BRAND` unset, so `app=None` reached the API client and setup failed with an endless "Failed to connect to Sage Coffee API" retry, with nothing pointing at the stale config key. The only workaround was to delete and re-add the integration.

## Changes

- `custom_components/sagecoffee/__init__.py` — new `async_migrate_entry` that rewrites the legacy `machine_type` key to `brand`, preserving the stored value, falling back to an existing `brand` and then to `MACHINE_TYPE_SAGE`. Downgrades from a newer schema return `False`.
- `custom_components/sagecoffee/config_flow.py` — `VERSION` 1 -> 2. A major bump rather than `MINOR_VERSION`, because the rename is not backwards compatible: a pre-rename build cannot read `brand`. The bump is what causes the migration to run at all.
- `custom_components/sagecoffee/__init__.py` — `app=entry.data.get(CONF_BRAND) or MACHINE_TYPE_SAGE` as belt-and-braces, and the broad `except Exception` around appliance discovery now logs the exception type so configuration errors are distinguishable from genuine connectivity failures.
- `custom_components/sagecoffee/const.py` — `CONF_MACHINE_TYPE_LEGACY`.
- `custom_components/sagecoffee/manifest.json` — integration version 1.4.0 -> 1.4.1, and `sagecoffee` pinned to 0.2.1.

## Library side

Paired with simonjgreen/sagecoffee#20, which stops a `None` app identifier reaching a request header — it previously surfaced as an opaque `TypeError: Header value must be str or bytes, not <class 'NoneType'>` from inside httpx.

That is merged and released as [sagecoffee v0.2.1](https://github.com/simonjgreen/sagecoffee/releases/tag/v0.2.1), published to PyPI, and pinned here. The pin has been confirmed to resolve.

## Testing

This repo has no test harness (no `tests/`, no pytest config), so nothing automated was added here. The migration was verified by inspection plus a standalone simulation of the transformation, covering: legacy `machine_type` with both `sageCoffee` and `brevilleCoffee` preserved, an already-migrated `brand`, neither key present (-> `sageCoffee`), and both keys present but `None` (-> `sageCoffee`).

The library change has test coverage in its own PR: 66 passed, up from 62, with nothing previously passing altered.