### PR TITLE
Publish releases as a zip archive

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,4 +1,4 @@
-name: Tag release from manifest version
+name: Draft release from manifest version
 
 on:
   push:
@@ -10,12 +10,10 @@ permissions:
   contents: write
 
 jobs:
-  tag:
+  draft:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Read version from manifest
         id: version
@@ -23,14 +21,27 @@ jobs:
           VERSION=$(jq -r .version custom_components/sagecoffee/manifest.json)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Create and push tag if missing
+      - name: Build release archive
+        run: |
+          cd custom_components/sagecoffee
+          zip -r "$GITHUB_WORKSPACE/sagecoffee.zip" . -x '*__pycache__*'
+
+      - name: Create or update draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, replacing archive"
+            gh release upload "$TAG" sagecoffee.zip --clobber
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          case "$TAG" in
+            *rc*|*beta*|*alpha*) PRERELEASE=--prerelease ;;
+            *) PRERELEASE= ;;
+          esac
+          gh release create "$TAG" sagecoffee.zip \
+            --draft $PRERELEASE \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "Sage Coffee",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true,
+  "filename": "sagecoffee.zip"
 }


### PR DESCRIPTION
Follows the most specific release path documented by HACS for integrations: `zip_release` + `filename` in `hacs.json`, with the workflow building `sagecoffee.zip` and opening a **draft** release for the manifest version.

- Archive contains the integration files at the archive root, which is where HACS extracts them.
- Release is left as a draft so notes stay hand-written; the tag is only created on publish.
- `rc`/`beta`/`alpha` versions are marked as prereleases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnNcD1yapsPqovNFPSjHiK