### PR TITLE
Add config flow tests and test infrastructure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Install test dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Sage Coffee Home Assistant Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
+[![Tests](https://github.com/simonjgreen/sageha/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/simonjgreen/sageha/actions/workflows/tests.yml)
+[![Validate](https://github.com/simonjgreen/sageha/actions/workflows/validate.yaml/badge.svg?branch=main)](https://github.com/simonjgreen/sageha/actions/workflows/validate.yaml)
 
 Home Assistant custom integration for Sage/Breville connected coffee machines.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = [
+    "--cov=custom_components.sagecoffee",
+    "--cov-report=term-missing",
+]
+
+[tool.coverage.run]
+source = ["custom_components/sagecoffee"]
+
+[tool.coverage.report]
+# Starting threshold from the config flow tests; raise as more tests land.
+fail_under = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ addopts = [
 source = ["custom_components/sagecoffee"]
 
 [tool.coverage.report]
-# Starting threshold from the config flow tests; raise as more tests land.
-fail_under = 20
+# Threshold from the initial test suite; raise as more tests land.
+fail_under = 85

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest-homeassistant-custom-component
+pytest-cov
+sagecoffee==0.2.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sage Coffee integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for Sage Coffee tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+MOCK_AUTH0_SUB = "auth0|1234567890"
+MOCK_REFRESH_TOKEN = "mock-refresh-token"
+MOCK_ROTATED_TOKEN = "mock-rotated-refresh-token"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
+    """Enable loading custom integrations in all tests."""
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Prevent actual integration setup when a config entry is created."""
+    with patch(
+        "custom_components.sagecoffee.async_setup_entry", return_value=True
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_tokens() -> MagicMock:
+    """A token set as returned by a successful authentication."""
+    tokens = MagicMock()
+    tokens.refresh_token = MOCK_ROTATED_TOKEN
+    tokens.auth0_sub.return_value = MOCK_AUTH0_SUB
+    return tokens
+
+
+@pytest.fixture
+def mock_auth_client(mock_tokens: MagicMock) -> Generator[MagicMock]:
+    """Patch AuthClient where the config flow imports it."""
+    with patch(
+        "custom_components.sagecoffee.config_flow.AuthClient", autospec=True
+    ) as mock_class:
+        client = mock_class.return_value
+        client.password_realm_login = AsyncMock(return_value=mock_tokens)
+        client.refresh = AsyncMock(return_value=mock_tokens)
+        yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,26 @@
 """Shared fixtures for Sage Coffee tests."""
 
+import asyncio
 from collections.abc import Generator
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sagecoffee.const import (
+    CONF_BRAND,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    MACHINE_TYPE_SAGE,
+)
+
 MOCK_AUTH0_SUB = "auth0|1234567890"
 MOCK_REFRESH_TOKEN = "mock-refresh-token"
 MOCK_ROTATED_TOKEN = "mock-rotated-refresh-token"
+MOCK_SERIAL = "SN12345678"
 
 
 @pytest.fixture(autouse=True)
@@ -43,3 +56,46 @@ def mock_auth_client(mock_tokens: MagicMock) -> Generator[MagicMock]:
         client.password_realm_login = AsyncMock(return_value=mock_tokens)
         client.refresh = AsyncMock(return_value=mock_tokens)
         yield client
+
+
+@pytest.fixture
+def mock_appliance() -> SimpleNamespace:
+    """A discovered appliance as returned by the sagecoffee client."""
+    return SimpleNamespace(serial_number=MOCK_SERIAL, name="Kitchen", model="BES995")
+
+
+@pytest.fixture
+def mock_client(mock_appliance: SimpleNamespace) -> Generator[MagicMock]:
+    """Patch SageCoffeeClient where the integration imports it."""
+    with patch(
+        "custom_components.sagecoffee.SageCoffeeClient", autospec=True
+    ) as mock_class:
+        client = mock_class.return_value
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.list_appliances = AsyncMock(return_value=[mock_appliance])
+        client.get_last_state = MagicMock(return_value=None)
+
+        async def tail_state():
+            # Keep the stream open until the listener task is cancelled.
+            await asyncio.Event().wait()
+            yield  # pragma: no cover
+
+        client.tail_state = tail_state
+        yield client
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """A current-version config entry registered with Home Assistant."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id=MOCK_AUTH0_SUB,
+        data={
+            CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
+            CONF_BRAND: MACHINE_TYPE_SAGE,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,337 @@
+"""Tests for the Sage Coffee config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sagecoffee.const import (
+    CONF_BRAND,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    MACHINE_TYPE_BREVILLE,
+    MACHINE_TYPE_SAGE,
+)
+
+from .conftest import MOCK_AUTH0_SUB, MOCK_REFRESH_TOKEN, MOCK_ROTATED_TOKEN
+
+PASSWORD_INPUT = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "hunter2",
+    CONF_BRAND: MACHINE_TYPE_SAGE,
+}
+
+TOKEN_INPUT = {
+    CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
+    CONF_BRAND: MACHINE_TYPE_BREVILLE,
+}
+
+
+async def test_user_step_shows_menu(hass: HomeAssistant) -> None:
+    """The initial step offers a choice between password and token auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+    assert result["menu_options"] == ["password", "token"]
+
+
+async def test_password_flow_creates_entry(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A successful password login creates an entry with token, brand and unique ID."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "password"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "password"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_REFRESH_TOKEN: MOCK_ROTATED_TOKEN,
+        CONF_BRAND: MACHINE_TYPE_SAGE,
+    }
+    assert result["result"].unique_id == MOCK_AUTH0_SUB
+    mock_auth_client.password_realm_login.assert_awaited_once_with(
+        "user@example.com", "hunter2"
+    )
+
+
+async def test_password_flow_invalid_auth_then_recover(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_tokens: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A failed login shows an error and the flow can still succeed afterwards."""
+    mock_auth_client.password_realm_login.side_effect = Exception("bad credentials")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "password"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_auth_client.password_realm_login.side_effect = None
+    mock_auth_client.password_realm_login.return_value = mock_tokens
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_password_flow_duplicate_account_aborts(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Logging in with an already-configured account aborts the flow."""
+    MockConfigEntry(domain=DOMAIN, unique_id=MOCK_AUTH0_SUB).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "password"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_password_flow_without_auth0_sub_creates_entry(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_tokens: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """When no auth0 subject is available the entry is created without a unique ID."""
+    mock_tokens.auth0_sub.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "password"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id is None
+
+
+async def test_token_flow_creates_entry_with_rotated_token(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A valid token creates an entry storing the rotated token from the refresh."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "token"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "token"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_REFRESH_TOKEN: MOCK_ROTATED_TOKEN,
+        CONF_BRAND: MACHINE_TYPE_BREVILLE,
+    }
+    assert result["result"].unique_id == MOCK_AUTH0_SUB
+    mock_auth_client.refresh.assert_awaited_once_with(MOCK_REFRESH_TOKEN)
+
+
+async def test_token_flow_keeps_original_token_when_not_rotated(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_tokens: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """If the refresh response has no new refresh token, the entered one is kept."""
+    mock_tokens.refresh_token = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "token"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_REFRESH_TOKEN] == MOCK_REFRESH_TOKEN
+
+
+async def test_token_flow_invalid_token_shows_error(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """An invalid token shows an error on the token form."""
+    mock_auth_client.refresh.side_effect = Exception("invalid token")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "token"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "token"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_token_flow_duplicate_account_aborts(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A token for an already-configured account aborts the flow."""
+    MockConfigEntry(domain=DOMAIN, unique_id=MOCK_AUTH0_SUB).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "token"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.fixture
+def existing_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """An existing config entry to reauthenticate against."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_AUTH0_SUB,
+        data={
+            CONF_REFRESH_TOKEN: "expired-token",
+            CONF_BRAND: MACHINE_TYPE_SAGE,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_reauth_password_updates_entry(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+    existing_entry: MockConfigEntry,
+) -> None:
+    """Reauthenticating with a password updates the stored token and brand."""
+    result = await existing_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reauth_password"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_password"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], PASSWORD_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert existing_entry.data == {
+        CONF_REFRESH_TOKEN: MOCK_ROTATED_TOKEN,
+        CONF_BRAND: MACHINE_TYPE_SAGE,
+    }
+
+
+async def test_reauth_token_updates_entry(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+    existing_entry: MockConfigEntry,
+) -> None:
+    """Reauthenticating with a token updates the stored token and brand."""
+    result = await existing_entry.start_reauth_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reauth_token"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_token"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert existing_entry.data == {
+        CONF_REFRESH_TOKEN: MOCK_ROTATED_TOKEN,
+        CONF_BRAND: MACHINE_TYPE_BREVILLE,
+    }
+
+
+async def test_reauth_token_failure_shows_error(
+    hass: HomeAssistant,
+    mock_auth_client: MagicMock,
+    mock_setup_entry: AsyncMock,
+    existing_entry: MockConfigEntry,
+) -> None:
+    """A failed reauth leaves the existing entry untouched and shows an error."""
+    mock_auth_client.refresh.side_effect = Exception("invalid token")
+
+    result = await existing_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reauth_token"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], TOKEN_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+    assert existing_entry.data[CONF_REFRESH_TOKEN] == "expired-token"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,225 @@
+"""Tests for the coordinator's device state parsing and auth error detection.
+
+Malformed device payloads have crashed the WebSocket listener before (#36),
+so `_update_state_from_device` is exercised against the messy shapes the
+device is known to send.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sagecoffee import SageCoffeeCoordinator, _is_auth_error
+from custom_components.sagecoffee.const import DOMAIN
+
+from .conftest import MOCK_SERIAL
+
+
+def make_coordinator(hass: HomeAssistant) -> SageCoffeeCoordinator:
+    """Build a coordinator with a mocked client and no appliances."""
+    entry = MockConfigEntry(domain=DOMAIN, version=2)
+    entry.add_to_hass(hass)
+    return SageCoffeeCoordinator(hass, MagicMock(), [], entry)
+
+
+def make_device_state(reported: dict[str, Any], **overrides: Any) -> SimpleNamespace:
+    """Build a DeviceState-shaped object with the given reported payload."""
+    defaults = {
+        "serial_number": MOCK_SERIAL,
+        "raw_data": {"reported": reported},
+        "reported_state": "ready",
+        "desired_state": "ready",
+        "version": 7,
+        "boiler_temps": [],
+        "grind_size": 15,
+    }
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+WELL_FORMED_REPORTED = {
+    "version": "1.2.3",
+    "model": "BES995",
+    "cfg": {
+        "default": {
+            "theme": "dark",
+            "brightness": 80,
+            "work_light_brightness": 50,
+            "vol": 60,
+            "idle_time": 20,
+            "temp_unit": 0,
+            "timezone": "Europe/London",
+            "wake_schedule": [{"cron": "30 6 * * *", "on": True}],
+        }
+    },
+    "pairing": {"remote_wake": True, "last_paired": 1755100800},
+    "firmware": {"appVersion": "2.0.1"},
+    "errors": [],
+}
+
+
+async def test_well_formed_payload_maps_all_keys(hass: HomeAssistant) -> None:
+    """A well-formed payload is mapped to the state dict every entity reads."""
+    coordinator = make_coordinator(hass)
+    boiler = SimpleNamespace(id="1", current_temp=93.0, target_temp=93.5)
+    state = make_device_state(WELL_FORMED_REPORTED, boiler_temps=[boiler])
+
+    coordinator._update_state_from_device(state)
+
+    parsed = coordinator.get_state(MOCK_SERIAL)
+    assert parsed == {
+        "reported_state": "ready",
+        "desired_state": "ready",
+        "state_report_version": 7,
+        "reported_version": "1.2.3",
+        "model": "BES995",
+        "boiler_temps": [{"id": "1", "cur_temp": 93.0, "temp_sp": 93.5}],
+        "grind_size": 15,
+        "theme": "dark",
+        "brightness": 80,
+        "work_light_brightness": 50,
+        "volume": 60,
+        "idle_time": 20,
+        "temperature_unit": 0,
+        "timezone": "Europe/London",
+        "remote_wake": True,
+        "last_paired": 1755100800,
+        "wake_schedule_raw": [{"cron": "30 6 * * *", "on": True}],
+        "wake_schedule": [{"cron": "30 6 * * *", "on": True}],
+        "firmware": {"appVersion": "2.0.1"},
+        "errors": [],
+    }
+
+
+async def test_flattened_cfg_default_key_fallback(hass: HomeAssistant) -> None:
+    """Some devices report a flattened "cfg.default" key instead of nested cfg."""
+    coordinator = make_coordinator(hass)
+    state = make_device_state({"cfg.default": {"theme": "light", "vol": 40}})
+
+    coordinator._update_state_from_device(state)
+
+    parsed = coordinator.get_state(MOCK_SERIAL)
+    assert parsed["theme"] == "light"
+    assert parsed["volume"] == 40
+
+
+@pytest.mark.parametrize(
+    "wake_schedule",
+    ["30 6 * * *", 42, {"cron": "30 6 * * *"}],
+    ids=["string", "int", "dict"],
+)
+async def test_non_list_wake_schedule_does_not_crash(
+    hass: HomeAssistant, wake_schedule: Any
+) -> None:
+    """A non-list wake_schedule is preserved raw but parsed as empty (#36)."""
+    coordinator = make_coordinator(hass)
+    state = make_device_state(
+        {"cfg": {"default": {"wake_schedule": wake_schedule}}}
+    )
+
+    coordinator._update_state_from_device(state)
+
+    parsed = coordinator.get_state(MOCK_SERIAL)
+    assert parsed["wake_schedule_raw"] == wake_schedule
+    assert parsed["wake_schedule"] == []
+
+
+async def test_wake_schedule_filters_non_dict_entries(hass: HomeAssistant) -> None:
+    """Non-dict entries inside the wake_schedule list are dropped (#36)."""
+    coordinator = make_coordinator(hass)
+    entry = {"cron": "30 6 * * *", "on": True}
+    state = make_device_state(
+        {"cfg": {"default": {"wake_schedule": ["bogus", entry, None]}}}
+    )
+
+    coordinator._update_state_from_device(state)
+
+    assert coordinator.get_state(MOCK_SERIAL)["wake_schedule"] == [entry]
+
+
+@pytest.mark.parametrize(
+    "reported",
+    [
+        {"cfg": {"default": "not-a-dict"}, "pairing": "not-a-dict"},
+        {},
+    ],
+    ids=["non_dict_sections", "empty"],
+)
+async def test_malformed_sections_do_not_crash(
+    hass: HomeAssistant, reported: dict[str, Any]
+) -> None:
+    """Non-dict cfg/pairing sections are treated as absent rather than crashing."""
+    coordinator = make_coordinator(hass)
+    state = make_device_state(reported)
+
+    coordinator._update_state_from_device(state)
+
+    parsed = coordinator.get_state(MOCK_SERIAL)
+    assert parsed["theme"] is None
+    assert parsed["remote_wake"] is None
+    assert parsed["wake_schedule"] == []
+
+
+async def test_remote_wake_falls_back_to_cfg_default(hass: HomeAssistant) -> None:
+    """Without pairing.remote_wake, cfg.default.remote_wake_enable is used."""
+    coordinator = make_coordinator(hass)
+    state = make_device_state(
+        {"cfg": {"default": {"remote_wake_enable": True}}, "pairing": {}}
+    )
+
+    coordinator._update_state_from_device(state)
+
+    assert coordinator.get_state(MOCK_SERIAL)["remote_wake"] is True
+
+
+async def test_none_boiler_temps_does_not_crash(hass: HomeAssistant) -> None:
+    """boiler_temps being None yields an empty list."""
+    coordinator = make_coordinator(hass)
+    state = make_device_state({}, boiler_temps=None)
+
+    coordinator._update_state_from_device(state)
+
+    assert coordinator.get_state(MOCK_SERIAL)["boiler_temps"] == []
+
+
+@pytest.mark.parametrize(
+    ("err", "expected"),
+    [
+        (
+            httpx.HTTPStatusError(
+                "unauthorised",
+                request=MagicMock(),
+                response=MagicMock(status_code=401),
+            ),
+            True,
+        ),
+        (
+            httpx.HTTPStatusError(
+                "forbidden",
+                request=MagicMock(),
+                response=MagicMock(status_code=403),
+            ),
+            True,
+        ),
+        (
+            httpx.HTTPStatusError(
+                "server error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            ),
+            False,
+        ),
+        (ValueError("Invalid refresh TOKEN"), True),
+        (ValueError("something else"), False),
+        (RuntimeError("token gone"), False),
+    ],
+    ids=["401", "403", "500", "token_value_error", "other_value_error", "other"],
+)
+def test_is_auth_error(err: Exception, expected: bool) -> None:
+    """Auth errors trigger reauth; anything else must not."""
+    assert _is_auth_error(err) is expected

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,266 @@
+"""Tests for integration setup, config entry migration, and services."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sagecoffee import async_migrate_entry
+from custom_components.sagecoffee.const import (
+    CONF_BRAND,
+    CONF_MACHINE_TYPE_LEGACY,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    MACHINE_TYPE_BREVILLE,
+    MACHINE_TYPE_SAGE,
+)
+
+from .conftest import MOCK_SERIAL
+
+
+async def setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> bool:
+    """Set up the given entry and settle the event loop."""
+    result = await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return result
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """A successful setup loads the entry, creates entities, and unloads cleanly."""
+    assert await setup_entry(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Each platform registered entities with the serial-prefixed unique ID scheme.
+    registry = er.async_get(hass)
+    unique_ids = {
+        e.unique_id
+        for e in er.async_entries_for_config_entry(registry, config_entry.entry_id)
+    }
+    assert f"{MOCK_SERIAL}_power" in unique_ids
+    assert f"{MOCK_SERIAL}_state" in unique_ids
+    assert f"{MOCK_SERIAL}_work_light" in unique_ids
+    assert len(unique_ids) == len(
+        er.async_entries_for_config_entry(registry, config_entry.entry_id)
+    ), "duplicate unique IDs registered"
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_client.__aexit__.assert_awaited()
+
+
+async def test_setup_without_refresh_token_starts_reauth(
+    hass: HomeAssistant, mock_client: MagicMock
+) -> None:
+    """A stored entry with no refresh token fails auth rather than retrying."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, data={CONF_BRAND: MACHINE_TYPE_SAGE}
+    )
+    entry.add_to_hass(hass)
+
+    assert not await setup_entry(hass, entry)
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert any(
+        flow["context"]["source"] == "reauth"
+        for flow in hass.config_entries.flow.async_progress()
+    )
+
+
+async def test_connection_failure_retries(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """A generic API failure is a retry (ConfigEntryNotReady), and closes the client."""
+    mock_client.list_appliances.side_effect = Exception("connection refused")
+
+    assert not await setup_entry(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    mock_client.__aexit__.assert_awaited_once()
+
+
+async def test_auth_failure_is_not_relabelled_as_retry(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """ConfigEntryAuthFailed from the client passes through untouched (#56)."""
+    mock_client.list_appliances.side_effect = ConfigEntryAuthFailed("token revoked")
+
+    assert not await setup_entry(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_client.__aexit__.assert_awaited_once()
+
+
+async def test_no_appliances_is_not_a_connection_failure(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """An empty appliance list retries with the brand-mismatch reason (#56)."""
+    mock_client.list_appliances.side_effect = None
+    mock_client.list_appliances.return_value = []
+
+    assert not await setup_entry(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "No appliances found" in str(config_entry.reason)
+    mock_client.__aexit__.assert_awaited_once()
+
+
+async def test_migrate_v1_machine_type_to_brand(hass: HomeAssistant) -> None:
+    """Version 1 entries storing machine_type are migrated to brand (#54)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={
+            CONF_REFRESH_TOKEN: "token",
+            CONF_MACHINE_TYPE_LEGACY: MACHINE_TYPE_BREVILLE,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.data == {
+        CONF_REFRESH_TOKEN: "token",
+        CONF_BRAND: MACHINE_TYPE_BREVILLE,
+    }
+
+
+async def test_migrate_v1_without_brand_defaults_to_sage(hass: HomeAssistant) -> None:
+    """Version 1 entries with neither key default to Sage rather than None (#54)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=1, data={CONF_REFRESH_TOKEN: "token"}
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.data[CONF_BRAND] == MACHINE_TYPE_SAGE
+
+
+async def test_migrate_from_newer_version_fails(hass: HomeAssistant) -> None:
+    """Entries from a newer integration version cannot be migrated down."""
+    entry = MockConfigEntry(domain=DOMAIN, version=3, data={})
+    entry.add_to_hass(hass)
+
+    assert not await async_migrate_entry(hass, entry)
+    assert entry.version == 3
+
+
+async def test_migrate_current_version_is_untouched(hass: HomeAssistant) -> None:
+    """Current-version entries pass through migration unchanged."""
+    data = {CONF_REFRESH_TOKEN: "token", CONF_BRAND: MACHINE_TYPE_SAGE}
+    entry = MockConfigEntry(domain=DOMAIN, version=2, data=data)
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.data == data
+
+
+async def test_set_wake_schedule_builds_cron(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """Day names are converted to the device's 1=Mon…7=Sun cron numbering."""
+    assert await setup_entry(hass, config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_wake_schedule",
+        {
+            "serial": MOCK_SERIAL,
+            "hours": 6,
+            "minutes": 30,
+            "days": ["mon", "sat", "sun"],
+        },
+        blocking=True,
+    )
+
+    mock_client.set_wake_schedule.assert_awaited_once_with(
+        cron="30 6 * * 1,6,7", enabled=True, serial=MOCK_SERIAL
+    )
+
+
+async def test_set_wake_schedule_without_days_means_every_day(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """Omitting days produces a wildcard day field."""
+    assert await setup_entry(hass, config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_wake_schedule",
+        {"serial": MOCK_SERIAL, "hours": 7, "minutes": 0, "enabled": False},
+        blocking=True,
+    )
+
+    mock_client.set_wake_schedule.assert_awaited_once_with(
+        cron="0 7 * * *", enabled=False, serial=MOCK_SERIAL
+    )
+
+
+async def test_set_wake_schedule_unknown_serial(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """An unknown serial raises a validation error rather than a crash."""
+    assert await setup_entry(hass, config_entry)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_wake_schedule",
+            {"serial": "NOPE", "hours": 6, "minutes": 30},
+            blocking=True,
+        )
+    mock_client.set_wake_schedule.assert_not_awaited()
+
+
+async def test_disable_wake_schedule_preserves_entries(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """Disabling flips each entry's "on" flag instead of sending an empty list (#47)."""
+    assert await setup_entry(hass, config_entry)
+
+    coordinator = config_entry.runtime_data
+    coordinator._states[MOCK_SERIAL] = {
+        "wake_schedule": [
+            {"cron": "30 6 * * 1-5", "on": True, "d": 1},
+            {"cron": "0 8 * * 6,7", "on": True, "d": 2},
+        ]
+    }
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_wake_schedule",
+        {"serial": MOCK_SERIAL},
+        blocking=True,
+    )
+
+    mock_client.set_coffee_params.assert_awaited_once_with(
+        {
+            "cfg": {
+                "wake_schedule": [
+                    {"cron": "30 6 * * 1-5", "on": False, "d": 1},
+                    {"cron": "0 8 * * 6,7", "on": False, "d": 2},
+                ]
+            }
+        },
+        serial=MOCK_SERIAL,
+    )
+
+
+async def test_disable_wake_schedule_with_no_schedule_sends_nothing(
+    hass: HomeAssistant, mock_client: MagicMock, config_entry: MockConfigEntry
+) -> None:
+    """With no known schedule there is nothing to disable, so no API call is made."""
+    assert await setup_entry(hass, config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_wake_schedule",
+        {"serial": MOCK_SERIAL},
+        blocking=True,
+    )
+
+    mock_client.set_coffee_params.assert_not_awaited()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,95 @@
+"""Tests for the work light's brightness conversion and state logic (#33)."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.components.light import ATTR_BRIGHTNESS
+
+from custom_components.sagecoffee.light import SageCoffeeWorkLight
+
+from .conftest import MOCK_SERIAL
+
+
+def make_light(state: dict[str, Any] | None) -> tuple[SageCoffeeWorkLight, MagicMock]:
+    """Build a work light entity backed by a mocked coordinator."""
+    coordinator = MagicMock()
+    coordinator.get_state.return_value = state
+    coordinator.client.set_work_light_brightness = AsyncMock()
+    appliance = SimpleNamespace(serial_number=MOCK_SERIAL, name="Kitchen", model="X")
+    return SageCoffeeWorkLight(coordinator, appliance), coordinator
+
+
+def test_is_on_reflects_brightness() -> None:
+    light, _ = make_light({"reported_state": "ready", "work_light_brightness": 50})
+    assert light.is_on is True
+
+    light, _ = make_light({"reported_state": "ready", "work_light_brightness": 0})
+    assert light.is_on is False
+
+
+def test_is_on_false_when_asleep_regardless_of_brightness() -> None:
+    light, _ = make_light({"reported_state": "asleep", "work_light_brightness": 50})
+    assert light.is_on is False
+
+
+def test_is_on_unknown_without_state() -> None:
+    light, _ = make_light(None)
+    assert light.is_on is None
+    assert light.brightness is None
+
+
+def test_brightness_scales_api_value_to_ha_range() -> None:
+    light, _ = make_light({"reported_state": "ready", "work_light_brightness": 100})
+    assert light.brightness == 255
+
+    light, _ = make_light({"reported_state": "ready", "work_light_brightness": 0})
+    assert light.brightness is None
+
+
+@pytest.mark.parametrize(
+    ("ha_brightness", "expected_api_value"),
+    [
+        (255, 100),  # full brightness
+        (128, 50),  # mid-scale rounds to nearest 10
+        (1, 10),  # turning on always gives a visible brightness
+    ],
+)
+async def test_turn_on_converts_and_clamps(
+    ha_brightness: int, expected_api_value: int
+) -> None:
+    light, coordinator = make_light(
+        {"reported_state": "ready", "work_light_brightness": 0}
+    )
+
+    await light.async_turn_on(**{ATTR_BRIGHTNESS: ha_brightness})
+
+    coordinator.client.set_work_light_brightness.assert_awaited_once_with(
+        expected_api_value, serial=MOCK_SERIAL
+    )
+
+
+async def test_turn_on_without_brightness_uses_full() -> None:
+    light, coordinator = make_light(
+        {"reported_state": "ready", "work_light_brightness": 0}
+    )
+
+    await light.async_turn_on()
+
+    coordinator.client.set_work_light_brightness.assert_awaited_once_with(
+        100, serial=MOCK_SERIAL
+    )
+
+
+async def test_turn_off_sends_zero() -> None:
+    light, coordinator = make_light(
+        {"reported_state": "ready", "work_light_brightness": 50}
+    )
+
+    await light.async_turn_off()
+
+    coordinator.client.set_work_light_brightness.assert_awaited_once_with(
+        0, serial=MOCK_SERIAL
+    )

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -1,0 +1,168 @@
+"""Tests for the pure helper functions behind the sensor platform."""
+
+from datetime import datetime, timezone
+import zoneinfo
+
+import pytest
+
+from custom_components.sagecoffee.sensor import (
+    _format_remote_wake,
+    _format_temperature_unit,
+    _format_wake_schedule,
+    _get_boiler_target,
+    _get_boiler_temp,
+    _get_errors_count,
+    _get_last_paired,
+    _get_next_wake_time,
+    _parse_cron_next,
+)
+
+UTC = zoneinfo.ZoneInfo("UTC")
+LONDON = zoneinfo.ZoneInfo("Europe/London")
+
+# A Wednesday, 10:00 UTC.
+WEDNESDAY = datetime(2026, 8, 12, 10, 0, tzinfo=UTC)
+
+
+class TestParseCronNext:
+    """The device cron format is "MM HH * * DAYS" with 1=Mon…7=Sun."""
+
+    def test_later_today(self) -> None:
+        result = _parse_cron_next("30 18 * * *", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 12, 18, 30, tzinfo=UTC)
+
+    def test_time_already_passed_rolls_to_tomorrow(self) -> None:
+        result = _parse_cron_next("30 6 * * *", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 13, 6, 30, tzinfo=UTC)
+
+    def test_specific_day_uses_device_numbering(self) -> None:
+        # Device day 6 = Saturday (1=Mon…7=Sun), not Python's 6=Sunday.
+        result = _parse_cron_next("0 7 * * 6", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 15, 7, 0, tzinfo=UTC)
+        assert result.weekday() == 5  # Saturday
+
+    def test_sunday_is_day_seven(self) -> None:
+        result = _parse_cron_next("0 7 * * 7", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 16, 7, 0, tzinfo=UTC)
+        assert result.weekday() == 6  # Sunday
+
+    def test_day_range(self) -> None:
+        # Mon-Fri; from Wednesday 10:00 the next 06:30 slot is Thursday.
+        result = _parse_cron_next("30 6 * * 1-5", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 13, 6, 30, tzinfo=UTC)
+
+    def test_day_list_skips_to_next_allowed_day(self) -> None:
+        # Sat,Sun only; from Wednesday the next slot is Saturday.
+        result = _parse_cron_next("0 8 * * 6,7", WEDNESDAY, UTC)
+        assert result == datetime(2026, 8, 15, 8, 0, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        "cron",
+        ["", "30 6 * *", "aa bb * * *", "30 6 * * x"],
+        ids=["empty", "four_fields", "non_numeric_time", "non_numeric_days"],
+    )
+    def test_malformed_cron_returns_none(self, cron: str) -> None:
+        assert _parse_cron_next(cron, WEDNESDAY, UTC) is None
+
+    def test_dst_transition_does_not_crash(self) -> None:
+        # UK clocks go forward 29 Mar 2026: 01:30 does not exist that day.
+        after = datetime(2026, 3, 28, 23, 0, tzinfo=LONDON)
+        result = _parse_cron_next("30 1 * * *", after, LONDON)
+        assert result is not None
+        assert (result.day, result.hour, result.minute) == (29, 1, 30)
+
+
+class TestGetNextWakeTime:
+    def test_picks_earliest_enabled_entry(self, freezer) -> None:
+        freezer.move_to("2026-08-12 10:00:00+00:00")
+        state = {
+            "timezone": "UTC",
+            "wake_schedule": [
+                {"cron": "0 18 * * *", "on": True},
+                {"cron": "0 6 * * *", "on": False},  # earlier but disabled
+                {"cron": "0 15 * * *", "on": True},
+            ],
+        }
+        assert _get_next_wake_time(state) == datetime(
+            2026, 8, 12, 15, 0, tzinfo=UTC
+        )
+
+    def test_unknown_timezone_falls_back_to_utc(self, freezer) -> None:
+        freezer.move_to("2026-08-12 10:00:00+00:00")
+        state = {
+            "timezone": "Not/AZone",
+            "wake_schedule": [{"cron": "0 18 * * *", "on": True}],
+        }
+        result = _get_next_wake_time(state)
+        assert result is not None
+        assert result.utcoffset().total_seconds() == 0
+
+    def test_no_enabled_entries_returns_none(self) -> None:
+        assert _get_next_wake_time({"wake_schedule": [], "timezone": "UTC"}) is None
+
+
+class TestBoilerLookup:
+    STATE = {"boiler_temps": [{"id": "0", "cur_temp": 135.0, "temp_sp": 135.5}]}
+
+    def test_matches_int_id_against_string_id(self) -> None:
+        # The library reports string IDs; lookups use int constants.
+        assert _get_boiler_temp(self.STATE, 0) == 135.0
+        assert _get_boiler_target(self.STATE, 0) == 135.5
+
+    def test_unknown_boiler_returns_none(self) -> None:
+        assert _get_boiler_temp(self.STATE, 1) is None
+        assert _get_boiler_target(self.STATE, 1) is None
+
+
+class TestGetLastPaired:
+    EXPECTED = datetime(2025, 8, 13, 16, 0, tzinfo=timezone.utc)
+
+    def test_epoch_seconds(self) -> None:
+        assert _get_last_paired({"last_paired": 1755100800}) == self.EXPECTED
+
+    def test_epoch_milliseconds_are_scaled(self) -> None:
+        assert _get_last_paired({"last_paired": 1755100800000}) == self.EXPECTED
+
+    def test_string_epoch(self) -> None:
+        assert _get_last_paired({"last_paired": "1755100800"}) == self.EXPECTED
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", "none", "not-a-number", {}],
+        ids=["none", "empty", "none_sentinel", "garbage", "dict"],
+    )
+    def test_unparseable_returns_none(self, value) -> None:
+        assert _get_last_paired({"last_paired": value}) is None
+
+
+class TestFormatters:
+    def test_temperature_unit(self) -> None:
+        assert _format_temperature_unit({"temperature_unit": 0}) == "Celsius"
+        assert _format_temperature_unit({"temperature_unit": 1}) == "Fahrenheit"
+        assert _format_temperature_unit({"temperature_unit": None}) is None
+        assert _format_temperature_unit({"temperature_unit": 2}) == "2"
+
+    def test_remote_wake(self) -> None:
+        assert _format_remote_wake({"remote_wake": True}) == "enabled"
+        assert _format_remote_wake({"remote_wake": False}) == "disabled"
+        assert _format_remote_wake({"remote_wake": None}) is None
+
+    def test_errors_count(self) -> None:
+        assert _get_errors_count({"errors": ["e1", "e2"]}) == 2
+        assert _get_errors_count({"errors": []}) == 0
+        assert _get_errors_count({"errors": None}) is None
+        assert _get_errors_count({"errors": "oops"}) is None
+
+    def test_wake_schedule_summary(self) -> None:
+        schedule = [
+            {"cron": "30 6 * * *", "on": True},
+            {"cron": "0 8 * * 6", "on": False},
+            "bogus",
+        ]
+        assert (
+            _format_wake_schedule({"wake_schedule_raw": schedule})
+            == "30 6 * * * (on), 0 8 * * 6 (off)"
+        )
+        assert _format_wake_schedule({"wake_schedule_raw": []}) == "none"
+        assert _format_wake_schedule({"wake_schedule_raw": None}) == "none"
+        assert _format_wake_schedule({"wake_schedule_raw": [{"on": True}]}) is None


### PR DESCRIPTION
Closes #12

## What this adds

**Test infrastructure** (per the plan in the issue comments):
- `pyproject.toml` — pytest configuration with coverage via `pytest-cov`, `--cov-report=term-missing`, and a `fail_under` threshold of 85% (current total is 86.7%). Raise the threshold as future PRs add tests.
- `requirements-test.txt` — `pytest-homeassistant-custom-component`, `pytest-cov`, `sagecoffee==0.2.2`
- `.github/workflows/tests.yml` — runs the suite on push, PR and manual dispatch
- `tests/conftest.py` — patches `AuthClient` and `SageCoffeeClient` at their import sites, with mock token/appliance/client fixtures

## Test suite (79 tests)

**Config flow** (`test_config_flow.py`) — the seven cases from the issue, updated for the brand selector added since it was filed, plus behaviour that has grown into the flow since:
- Menu step, password and token flows: success, invalid credentials with in-flow recovery, duplicate account abort
- Token rotation fallback: the entered token is kept when `refresh()` doesn't rotate it
- `auth0_sub()` returning `None` still creates the entry, without a unique ID
- Reauth via password and token updates the existing entry; failed reauth leaves the stored token untouched

**Coordinator** (`test_coordinator.py`) — `_update_state_from_device` against the messy payload shapes that previously crashed the WebSocket listener (#36): non-list `wake_schedule`, non-dict entries, non-dict cfg/pairing sections, the flattened `cfg.default` key fallback, the `remote_wake` fallback chain, and a full well-formed payload mapping as the regression net for the entity layer. Plus `_is_auth_error` classification (401/403/token errors trigger reauth; 500s and generic errors must not).

**Setup, migration and services** (`test_init.py`):
- Setup/unload smoke test asserting entity unique IDs and client cleanup
- Error classification pinning #56: generic failure → retry, `ConfigEntryAuthFailed` passes through untouched, empty appliance list → retry with the brand-mismatch reason, missing token → reauth; the client is closed on every failure path
- Config entry migration from v1 `machine_type` (#54), including the default-to-Sage and newer-version-refused paths
- Wake schedule services: day-name → device cron numbering (1=Mon…7=Sun), wildcard days, unknown serial validation, and the #47 disable behaviour (entries preserved with `"on": false`, nothing sent when no schedule is known)

**Work light** (`test_light.py`) — the #33 territory: HA 1–255 ↔ API 1–100 brightness conversion with rounding and the minimum-10 clamp, `is_on` forced off when asleep, unknown state handling.

**Sensor helpers** (`test_sensor_helpers.py`) — `_parse_cron_next` (device day numbering, ranges, rollover, malformed crons, DST transition), `_get_last_paired` (seconds vs milliseconds heuristic, string epochs, sentinels), boiler string-ID lookup, and the formatter edge cases.

## Noted but not changed

`_update_state_from_device` would still crash if a device reported `"cfg"` itself as a non-dict (the #36 fix guards `cfg.default` and `pairing`, but `reported.get("cfg", {}).get(...)` assumes `cfg` is a dict when present). Left out of this tests-only PR; a one-line `isinstance` guard would close it.

All 79 tests pass locally on Python 3.14 / HA 2026.8.1; coverage is 86.7% overall.
