### PR TITLE
Add low-water and empty-tank binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Home Assistant custom integration for Sage/Breville connected coffee machines.
 - **Real-time State Monitoring**: See if your machine is ready, warming up, or asleep
 - **Temperature Sensors**: Monitor brew and steam boiler temperatures
 - **Configuration Sensors**: View theme, brightness, grind size, and more
+- **Low-water Fault Sensor**: Detect reported low-water and empty-tank warnings
 - **Wake Schedule**: See when your machine is next scheduled to switch on automatically
 - **Firmware Version**: Check the installed firmware version from the device page
 
@@ -93,6 +94,18 @@ For each coffee machine, the integration creates:
 | ------------------ | --------------------------------- |
 | Display Brightness | Set display brightness percentage |
 | Volume             | Set volume level percentage       |
+
+### Binary Sensors
+
+| Entity    | Description                                         |
+| --------- | --------------------------------------------------- |
+| Low Water | Problem indicator for low-water or empty-tank faults |
+
+Low Water turns on for error code `31102` (low water) or `29120` (empty tank),
+and off when a valid reported error list contains neither code. Missing or
+malformed error data makes the sensor unavailable unless a recognized water
+fault is present. Updates depend on Sage/Breville cloud reports and can be
+delayed. This is not a water-level percentage.
 
 ### Sensors
 

--- a/custom_components/sagecoffee/binary_sensor.py
+++ b/custom_components/sagecoffee/binary_sensor.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
 class SageCoffeeLowWaterSensor(SageCoffeeEntity, BinarySensorEntity):
     """Report the machine's water fault without estimating its water level."""
 
-    _attr_name = "Low Water"
+    _attr_translation_key = "low_water"
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_icon = "mdi:water-alert"
 

--- a/custom_components/sagecoffee/binary_sensor.py
+++ b/custom_components/sagecoffee/binary_sensor.py
@@ -1,0 +1,76 @@
+"""Low-water fault sensor for the Sage Coffee integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SageCoffeeConfigEntry, SageCoffeeCoordinator
+from .entity import SageCoffeeEntity
+
+LOW_WATER_ERROR_CODES = frozenset({31102, 29120})
+
+
+def _low_water_state(state: dict[str, Any] | None) -> bool | None:
+    """Decode low-water and empty-tank faults, preserving missing data."""
+    if not isinstance(state, dict):
+        return None
+    errors = state.get("errors")
+    if not isinstance(errors, list):
+        return None
+
+    malformed = False
+    for error in errors:
+        code = error.get("code") if isinstance(error, dict) else None
+        if isinstance(code, str) and code.isascii() and code.isdecimal():
+            code = int(code)
+        if type(code) is not int:
+            malformed = True
+            continue
+        if code in LOW_WATER_ERROR_CODES:
+            return True
+    return None if malformed else False
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SageCoffeeConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up one low-water sensor for each appliance."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        [
+            SageCoffeeLowWaterSensor(coordinator, appliance)
+            for appliance in coordinator.appliances
+        ]
+    )
+
+
+class SageCoffeeLowWaterSensor(SageCoffeeEntity, BinarySensorEntity):
+    """Report the machine's water fault without estimating its water level."""
+
+    _attr_name = "Low Water"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_icon = "mdi:water-alert"
+
+    def __init__(
+        self, coordinator: SageCoffeeCoordinator, appliance: Any
+    ) -> None:
+        """Initialize the low-water sensor."""
+        super().__init__(coordinator, appliance)
+        self._attr_unique_id = f"{self._serial}_low_water"
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.is_on is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        return _low_water_state(self.coordinator.get_state(self._serial))

--- a/custom_components/sagecoffee/const.py
+++ b/custom_components/sagecoffee/const.py
@@ -38,4 +38,4 @@ SENSOR_VOLUME = "volume"
 SENSOR_AUTO_OFF = "auto_off"
 
 # Platforms
-PLATFORMS = ["switch", "sensor", "text", "select", "number", "light"]
+PLATFORMS = ["switch", "sensor", "text", "select", "number", "light", "binary_sensor"]

--- a/custom_components/sagecoffee/strings.json
+++ b/custom_components/sagecoffee/strings.json
@@ -81,6 +81,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "low_water": {
+        "name": "Low Water"
+      }
+    },
     "light": {
       "work_light": {
         "name": "Work Light"

--- a/custom_components/sagecoffee/translations/en.json
+++ b/custom_components/sagecoffee/translations/en.json
@@ -122,6 +122,11 @@
         "name": "Errors Count"
       }
     },
+    "binary_sensor": {
+      "low_water": {
+        "name": "Low Water"
+      }
+    },
     "switch": {
       "power": {
         "name": "Power"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -75,6 +75,7 @@ def test_entity_metadata_and_coordinator_availability(
     sensor = SageCoffeeLowWaterSensor(coordinator, mock_appliance)
 
     assert sensor.unique_id == f"{MOCK_SERIAL}_low_water"
+    assert sensor.translation_key == "low_water"
     assert sensor.device_class is BinarySensorDeviceClass.PROBLEM
     assert sensor.available is True
     assert sensor.is_on is False
@@ -136,6 +137,7 @@ async def test_entity_registration_and_pushed_state_changes(
     assert (DOMAIN, MOCK_SERIAL) in device.identifiers
     assert entity.config_entry_id == config_entry.entry_id
     assert hass.states.get(entity_id).state == STATE_OFF
+    assert hass.states.get(entity_id).attributes["friendly_name"].endswith("Low Water")
 
     coordinator = config_entry.runtime_data
     for errors, expected in (

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,155 @@
+"""Tests for reported low-water and empty-tank faults."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sagecoffee.binary_sensor import (
+    SageCoffeeLowWaterSensor,
+    _low_water_state,
+    async_setup_entry,
+)
+from custom_components.sagecoffee.const import DOMAIN, PLATFORMS
+
+from .conftest import MOCK_SERIAL
+
+
+@pytest.mark.parametrize("code", [31102, 29120, "31102", "29120"])
+def test_both_water_fault_codes(code: int | str) -> None:
+    assert _low_water_state({"errors": [{"code": code}]}) is True
+
+
+@pytest.mark.parametrize("errors", [[], [{"code": 99999}], [{"code": "99999"}]])
+def test_report_without_water_fault_is_clear(errors: list[dict[str, Any]]) -> None:
+    assert _low_water_state({"errors": errors}) is False
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        None,
+        {},
+        {"errors": None},
+        {"errors": {}},
+        {"errors": "[]"},
+        {"errors": [None]},
+        {"errors": [31102]},
+        {"errors": [{}]},
+        {"errors": [{"code": None}]},
+        {"errors": [{"code": True}]},
+        {"errors": [{"code": 31102.5}]},
+        {"errors": [{"code": "unknown"}]},
+        {"errors": [{"code": 99999}, {}]},
+    ],
+)
+def test_missing_or_malformed_data_is_unknown(state: dict[str, Any] | None) -> None:
+    assert _low_water_state(state) is None
+
+
+@pytest.mark.parametrize(
+    "errors", [[None, {"code": 31102}], [{"code": 29120}, None]]
+)
+def test_conclusive_fault_survives_malformed_entries(errors: list[Any]) -> None:
+    assert _low_water_state({"errors": errors}) is True
+
+
+def test_platform_preserves_existing_platforms() -> None:
+    assert "binary_sensor" in PLATFORMS
+    assert {"switch", "sensor", "text", "select", "number", "light"} <= set(PLATFORMS)
+
+
+def test_entity_metadata_and_coordinator_availability(
+    mock_appliance: SimpleNamespace,
+) -> None:
+    coordinator = MagicMock(last_update_success=True)
+    coordinator.get_state.return_value = {"errors": []}
+    sensor = SageCoffeeLowWaterSensor(coordinator, mock_appliance)
+
+    assert sensor.unique_id == f"{MOCK_SERIAL}_low_water"
+    assert sensor.device_class is BinarySensorDeviceClass.PROBLEM
+    assert sensor.available is True
+    assert sensor.is_on is False
+    coordinator.get_state.assert_called_with(MOCK_SERIAL)
+
+    coordinator.last_update_success = False
+    assert sensor.available is False
+
+
+async def test_setup_adds_one_sensor_per_appliance(hass: HomeAssistant) -> None:
+    appliances = [
+        SimpleNamespace(serial_number=serial, name="Kitchen", model="BES995")
+        for serial in ("TEST-ONE", "TEST-TWO")
+    ]
+    coordinator = MagicMock(appliances=appliances)
+    add_entities = MagicMock()
+
+    await async_setup_entry(
+        hass, SimpleNamespace(runtime_data=coordinator), add_entities
+    )
+
+    sensors = add_entities.call_args.args[0]
+    assert [sensor.unique_id for sensor in sensors] == [
+        "TEST-ONE_low_water",
+        "TEST-TWO_low_water",
+    ]
+    assert all(sensor.coordinator is coordinator for sensor in sensors)
+
+
+async def test_entity_registration_and_pushed_state_changes(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    device_state = SimpleNamespace(
+        serial_number=MOCK_SERIAL,
+        raw_data={"reported": {"errors": []}},
+        reported_state="ready",
+        desired_state=None,
+        version=1,
+        boiler_temps=[],
+        grind_size=None,
+    )
+    mock_client.get_last_state.return_value = device_state
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{MOCK_SERIAL}_low_water"
+    )
+    assert entity_id is not None
+    entity = registry.async_get(entity_id)
+    device = dr.async_get(hass).async_get_device({(DOMAIN, MOCK_SERIAL)})
+    assert entity is not None
+    assert device is not None
+    assert entity.device_id == device.id
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    coordinator = config_entry.runtime_data
+    for errors, expected in (
+        ([{"code": 29120}], STATE_ON),
+        ([], STATE_OFF),
+        (None, STATE_UNAVAILABLE),
+        ([{"code": "31102"}], STATE_ON),
+        ([{}], STATE_UNAVAILABLE),
+        ([], STATE_OFF),
+    ):
+        device_state.raw_data["reported"]["errors"] = errors
+        coordinator._update_state_from_device(device_state)
+        coordinator.async_set_updated_data(coordinator._states)
+        await hass.async_block_till_done()
+        assert hass.states.get(entity_id).state == expected
+
+    coordinator.async_set_update_error(UpdateFailed("Disconnected"))
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -129,10 +129,12 @@ async def test_entity_registration_and_pushed_state_changes(
     )
     assert entity_id is not None
     entity = registry.async_get(entity_id)
-    device = dr.async_get(hass).async_get_device({(DOMAIN, MOCK_SERIAL)})
     assert entity is not None
+    assert entity.device_id is not None
+    device = dr.async_get(hass).async_get(entity.device_id)
     assert device is not None
-    assert entity.device_id == device.id
+    assert (DOMAIN, MOCK_SERIAL) in device.identifiers
+    assert entity.config_entry_id == config_entry.entry_id
     assert hass.states.get(entity_id).state == STATE_OFF
 
     coordinator = config_entry.runtime_data


### PR DESCRIPTION
## Summary

Add a `Low Water` problem-class binary sensor for each appliance, using the
`errors` already retained by `SageCoffeeCoordinator`. No client changes,
additional polling, services, or machine commands are introduced.

- Recognize `31102` (`LowWaterLevel`) and `29120` (`WaterTankEmpty`), including decimal-string codes.
- Report off for an explicit, valid error list containing neither water fault.
- Treat missing or malformed error data as unavailable, unless a recognized water fault is present, and honor coordinator availability.
- Register the binary-sensor platform, add the English entity name, and document the fault-only behavior and cloud-update delay.

This is not a water-level percentage or a guarantee of immediate fault delivery.

## Evidence

Investigation used an owned Oracle Dual Boiler BES995 and the official Android
app 1.26.2 (build 701). The app maps both codes to its low-water indication.

During an idle tank-removal test, a real cloud report contained this reported-state fragment:

```json
{"errors": [{"code": 29120}]}
```

Refitting the tank produced `{"errors": []}`. Code `31102` was identified in the
app and covered by tests, but was not physically induced. No pump or dry-running
test was used.

The same fault-decoding logic was deployed on sageha 1.4.2 / Home Assistant
2026.9.0. The new entity loaded, reported off after the tank was refitted, and all
25 existing entities remained available. A physical on/off transition after
deployment has not yet been verified.

## Validation

- [Linux / Python 3.14 tests](https://github.com/simonjgreen/sageha/actions/runs/33958136083): **105 passed**, **90.25% coverage**, above the existing 85% requirement.
- 26 new test cases cover both code types, clear/unknown/malformed data, conclusive faults, per-appliance setup, real HA entity/device registration, the translated name, pushed on/off/unavailable transitions, and coordinator failure.
- [Hassfest](https://github.com/simonjgreen/sageha/actions/runs/33958136102): passed.
- [HACS validation](https://github.com/simonjgreen/sageha/actions/runs/33958136084): passed upstream. No workflow or repository-setting changes are included.

## Follow-up Findings (Not Implemented Here)

**F1: Maintenance status.** The app's `getApplianceMaintenance` reads
`reported.maintenance`, with model guards including BES995 and BES1010. Its
catalog includes `steamRinse`, `steamClean`, `groupHeadClean`, `descale`,
`changeWaterFilter`, `waterHardnessTest`, and `emptyBoilers`, with statuses
`0=NotNeeded`, `1=Scheduled`, `2=InProgress`, and `3=Completed`. No maintenance
field appeared in the captured BES995 reports. A useful next step is to capture
a genuine maintenance reminder or normal cleaning cycle before adding entities.

**F2: Incremental reports in the client library.** The app has separate
`stateReport` and `changeReport` handlers, whereas sagecoffee 0.2.2 handles
`stateReport`. No actual `changeReport` was observed in these captures, so this
is a compatibility lead, not proof of lost updates. Capture a real payload and
establish partial-update semantics before implementing support in
[sagecoffee](https://github.com/simonjgreen/sagecoffee).

**F3: Detailed fault diagnostics.** The integration currently exposes an error
count rather than individual fault codes or descriptions. The app has a wider
error catalog. Reported codes could support diagnostic attributes or additional
fault sensors, but each human-readable mapping should be verified against real
payloads rather than inferred from a generic error string.

**F4: Report freshness and connection diagnostics.** A brief repeated tank
removal/refit was not observed by the continuous listener, although the earlier
snapshot exposed the water fault. The cause is not established. Timestamped,
redacted captures and last-report/connection diagnostics would help distinguish
device/cloud timing from client behavior before changing polling or reconnect
logic.

## What Was Not Established

The decoded app/cloud reports sampled during idle, warming, and coffee-making
sessions did not expose brew pressure, flow, dose, shot duration, water-level
percentage, or drink counters. This does not prove those fields never exist.
Other unmapped fields were OTA request/delta bookkeeping, not established coffee
telemetry. The machine's separate port-8883 TLS traffic remained encrypted and
does not demonstrate any additional readable telemetry.

No credentials, serial numbers, private network details, APKs, or packet captures
are included in this contribution.